### PR TITLE
Add guest line item API

### DIFF
--- a/apps/snitch_api/lib/snitch_api_web/controllers/hosted_payment_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/hosted_payment_controller.ex
@@ -35,7 +35,7 @@ defmodule SnitchApiWeb.HostedPaymentController do
     url = Application.fetch_env!(:snitch_api, :frontend_checkout_url)
 
     with {:ok, order} <- HostedPayment.payment_order_context(response) do
-      address = url <> "order-success?orderReferance=#{order.id}"
+      address = url <> "order-success?orderReferance=#{order.number}"
 
       redirect(
         conn,

--- a/apps/snitch_api/lib/snitch_api_web/controllers/order_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/order_controller.ex
@@ -81,7 +81,7 @@ defmodule SnitchApiWeb.OrderController do
           preload: [product: [:theme, [options: :option_type]]]
         )
 
-      order = order |> Repo.preload(line_items: line_item_query)
+      order = order |> Repo.preload([[line_items: line_item_query], :packages, :payments])
 
       conn
       |> put_status(200)
@@ -91,7 +91,7 @@ defmodule SnitchApiWeb.OrderController do
         data: order,
         opts: [
           include:
-            "line_items,line_items.product,line_items.product.options,line_items.product.options.option_type"
+            "line_items,line_items.product,line_items.product.options,line_items.product.options.option_type,payments,packages"
         ]
       )
     else
@@ -106,7 +106,10 @@ defmodule SnitchApiWeb.OrderController do
     user_id = Map.get(conn.assigns[:current_user], :id)
 
     {:ok, order} = OrderModel.user_order(user_id)
-    order = order |> Repo.preload(line_items: [product: [:theme, [options: :option_type]]])
+
+    order =
+      order
+      |> Repo.preload(line_items: [product: [:theme, [options: :option_type]]], packages: :items)
 
     conn
     |> put_status(200)
@@ -116,7 +119,7 @@ defmodule SnitchApiWeb.OrderController do
       data: order,
       opts: [
         include:
-          "line_items,line_items.product,line_items.product.options,line_items.product.options.option_type"
+          "line_items,line_items.product,line_items.product.options,line_items.product.options.option_type,packages,packages.items"
       ]
     )
   end

--- a/apps/snitch_api/lib/snitch_api_web/cors.ex
+++ b/apps/snitch_api/lib/snitch_api_web/cors.ex
@@ -6,7 +6,7 @@ defmodule ApiWeb.CORS do
     log: [rejected: :error],
     allow_credentials: true,
     allow_headers: ["content-type", "token-type", "authorization"],
-    allow_methods: ["GET", "PUT", "OPTIONS", "DELETE"],
+    allow_methods: ["GET", "PUT", "OPTIONS", "DELETE", "PATCH"],
     max_age: 600
 
   resource("/*")

--- a/apps/snitch_api/lib/snitch_api_web/router.ex
+++ b/apps/snitch_api/lib/snitch_api_web/router.ex
@@ -30,6 +30,7 @@ defmodule SnitchApiWeb.Router do
     get("/countries/:id/states/", AddressController, :country_states)
     get("/brands", ProductBrandController, :index)
     post("/product_option_values/:id", ProductOptionValueController, :update)
+    post("/guest/line_items", LineItemController, :guest_line_item)
   end
 
   scope "/api/v1", SnitchApiWeb do


### PR DESCRIPTION
Adds add to cart API that can be used to create guest order.

## Motivation and Context
A guest user should be able to add line item to cart, so Line Item API is required for adding line items.

## Describe your changes
`snitch_api`
----------------
- Add API endpoint for adding line item 

## Any further comments?
- When we pass only `product id` and `quantity` to API. It will create a new order and line item for that product.
- If we pass `order id` with `product id` then the order is updated for that product.

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
