### PR TITLE
Fixes routes of hardcoded routes of API invoked in admin app.

### DIFF
--- a/apps/admin_app/assets/js/views/product/edit.js
+++ b/apps/admin_app/assets/js/views/product/edit.js
@@ -131,21 +131,21 @@ function setup_product() {
     get_variation_options(theme_id, product_id)
 }
 
-function update_option_value(id, value) {
-  $.ajax({
-    type: "POST",
-    url: 'http://localhost:3000/api/v1/product_option_values/' + id,
-    crossDomain: true,
-    data: {
-      value: value
-    },
-    success: function (response) {}
-  })
-}
+function update_option_value(id, value){
+    $.ajax({
+      type: "POST",
+      url: '/api/product_option_values/' + id,
+      crossDomain: true,
+      data: {value: value},
+      success: function(response){
+      }
+    })
+  }
 
-function get_variation_options(theme_id, product_id) {
-  fetch('http://localhost:4000/api/option_types?theme_id=' + theme_id + "&product_id=" + product_id)
-    .then(function (response) {
+  function get_variation_options(theme_id, product_id)
+  {
+    fetch('/api/option_types?theme_id=' + theme_id + "&product_id=" + product_id)
+    .then(function(response) {
       return response.json();
     })
     .then(function (myJson) {

--- a/apps/admin_app/assets/js/views/product/product_category.js
+++ b/apps/admin_app/assets/js/views/product/product_category.js
@@ -5,14 +5,14 @@ export default class View extends MainView {
       super.mount();
       get_categories(1)
       handle_category_click();
-  
+
       // Specific logic here
       console.log('ProductProduct_categoryView mounted');
     }
-  
+
     unmount() {
       super.unmount();
-  
+
       // Specific logic here
       console.log('ProductProduct_categoryView unmounted');
     }
@@ -25,7 +25,7 @@ export default class View extends MainView {
 function get_categories(id)
 {
   $(`#category_loader`).addClass(`loader`).show();
-  fetch('http://localhost:4000/api/categories/' + id)
+  fetch('/api/categories/' + id)
   .then(function(response) {
     return response.json();
   })
@@ -40,24 +40,23 @@ function handle_category_click(){
     $(`#category_selection`)
     .on("click", "li", function(e){
       let clicked_li = $(e.target);
-  
+
       //clear existing active li
       var ul =  clicked_li.closest("ul");
-  
+
       ul
       .children()
       .each(function(){
         $(this).removeClass(`active`);
       });
-  
+
       //remove all categories after
       var card = ul.closest('.card--content');
       card.nextAll().remove();
-  
+
       var next_taxon_id = clicked_li.data('taxon_id');
       clicked_li.addClass('active')
-  
+
       get_categories(next_taxon_id);
     })
   }
-  

--- a/apps/admin_app/assets/js/views/taxonomy/taxonomy.js
+++ b/apps/admin_app/assets/js/views/taxonomy/taxonomy.js
@@ -10,7 +10,7 @@ export default class View extends MainView {
         var id = $(this).closest('.item').data("taxon_id");
         $(`#taxon-edit-loader`).addClass(`loader`).show();
 
-        fetch('http://localhost:4000/api/taxon/' + id)
+        fetch('/api/taxon/' + id)
         .then(function(response) {
           return response.json()
         })
@@ -22,6 +22,7 @@ export default class View extends MainView {
           select2Selector()
         })
       })
+
       $(".mycontainer")
         .on("click", ".add-taxon", function(){
         $("#taxon-modal").modal({show: true})

--- a/apps/admin_app/lib/admin_app_web/controllers/template_api/option_type_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/template_api/option_type_controller.ex
@@ -2,7 +2,7 @@ defmodule AdminAppWeb.TemplateApi.OptionTypeController do
   use AdminAppWeb, :controller
 
   alias AdminAppWeb.TemplateApi.OptionTypeView
-  alias Snitch.Data.Model.VariationTheme
+  alias Snitch.Data.Model.{VariationTheme, ProductOptionValue}
   import Phoenix.View, only: [render_to_string: 3]
 
   def index(conn, %{"theme_id" => theme_id} = params) do
@@ -17,5 +17,12 @@ defmodule AdminAppWeb.TemplateApi.OptionTypeController do
     conn
     |> put_status(200)
     |> json(%{html: html})
+  end
+
+  def update(conn, %{"id" => id} = params) do
+    with option_value <- ProductOptionValue.get(id),
+         {:ok, option_value} <- ProductOptionValue.update(option_value, params) do
+      render(conn, "option_value.json", option_value: option_value)
+    end
   end
 end

--- a/apps/admin_app/lib/admin_app_web/router.ex
+++ b/apps/admin_app/lib/admin_app_web/router.ex
@@ -96,5 +96,6 @@ defmodule AdminAppWeb.Router do
     resources("/option_types", OptionTypeController)
     get("/categories/:taxon_id", TaxonomyController, :index)
     get("/taxon/:taxon_id", TaxonomyController, :taxon_edit)
+    post("/product_option_values/:id", OptionTypeController, :update)
   end
 end

--- a/apps/admin_app/lib/admin_app_web/views/template_api/option_type_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/template_api/option_type_view.ex
@@ -1,3 +1,7 @@
 defmodule AdminAppWeb.TemplateApi.OptionTypeView do
   use AdminAppWeb, :view
+
+  def render("option_value.json", %{option_value: option_value}) do
+    Map.take(option_value, [:value, :option_type_id, :display_name])
+  end
 end


### PR DESCRIPTION
Remove domain of hardcoded URL's from javascript of admin app

## Motivation and Context
Admin app had hardecoded URL's in javascript for API calls. Those API call will fail after deployment.

## Describe your changes
- Made all call without domain.
- Moved option value edit API to admin app.

## Any further comments?

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
