### PR TITLE
[Admin] Disable variation tab for child product.

### DIFF
--- a/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
@@ -1,20 +1,20 @@
 <ul class="nav nav-tabs">
-  <li class="nav-item">
-    <a class="nav-link active" href="#tab1default" data-toggle="tab">Product Detail</a>
-  </li>
-  <%= if  @conn.request_path != product_path(@conn, :new) do %>
-  <%= if has_themes(@parent_product) do %>
-  <li class="nav-item">
-    <a class="nav-link" href="#tab2default" data-toggle="tab">Variants</a>
-  </li>
-  <% end %>
-  <li class="nav-item">
-    <a class="nav-link" href="#tab3default" data-toggle="tab">Images</a>
-  </li>
-  <li class="nav-item">
-    <a class="nav-link" href="#tab4default" data-toggle="tab">Stock</a>
-  </li>
-  <% end %>
+   <li class="nav-item">
+      <a class="nav-link active" href="#tab1default" data-toggle="tab">Product Detail</a>
+   </li>
+   <%= if  @conn.request_path != product_path(@conn, :new) do %>
+   <%= if can_add_variant(@parent_product) do %>
+    <li class="nav-item">
+        <a class="nav-link" href="#tab2default" data-toggle="tab">Variants</a>
+    </li>
+   <% end %>
+   <li class="nav-item">
+      <a class="nav-link" href="#tab3default" data-toggle="tab">Images</a>
+   </li>
+   <li class="nav-item">
+      <a class="nav-link" href="#tab4default" data-toggle="tab">Stock</a>
+   </li>
+   <% end %>
 </ul>
 <div class="tab-content">
   <div class="tab-pane fade in active show" id="tab1default">
@@ -30,7 +30,7 @@
         </div>
         <div class="label-txt">Include keywords that buyers would use to search for your item.</div>
       </label>
-      <div class="col-sm-9">           
+      <div class="col-sm-9">
         <%= input f, :name%>
       </div>
     </div>
@@ -41,7 +41,7 @@
         </div>
         <div class="label-txt">Include keywords that buyers would use to search for your item.</div>
       </label>
-      <div class="col-sm-9">           
+      <div class="col-sm-9">
         <%= textarea_input f, :description%>
       </div>
     </div>
@@ -80,7 +80,7 @@
         </div>
         <div class="label-txt">Include keywords that buyers would use to search for your item.</div>
       </label>
-      <div class="col-sm-9">           
+      <div class="col-sm-9">
         <%= textarea_input f, :meta_description%>
       </div>
     </div>
@@ -91,7 +91,7 @@
         </div>
         <div class="label-txt">Include keywords that buyers would use to search for your item.</div>
       </label>
-      <div class="col-sm-9">           
+      <div class="col-sm-9">
         <%= select_input f, :brand_id, get_brand_options(@brands) %>
       </div>
     </div>
@@ -102,7 +102,7 @@
         </div>
         <div class="label-txt">Include keywords that buyers would use to search for your item.</div>
       </label>
-      <div class="col-sm-9">           
+      <div class="col-sm-9">
         <%= input f, :meta_keywords%>
       </div>
     </div>
@@ -113,7 +113,7 @@
         </div>
         <div class="label-txt">Include keywords that buyers would use to search for your item.</div>
       </label>
-      <div class="col-sm-9">           
+      <div class="col-sm-9">
         <%= input f, :meta_title%>
       </div>
     </div>
@@ -124,7 +124,7 @@
         </div>
         <div class="label-txt">Include keywords that buyers would use to search for your item.</div>
       </label>
-      <div class="col-sm-9">           
+      <div class="col-sm-9">
         <%= input f, :height %>
       </div>
     </div>
@@ -135,7 +135,7 @@
         </div>
         <div class="label-txt">Include keywords that buyers would use to search for your item.</div>
       </label>
-      <div class="col-sm-9">           
+      <div class="col-sm-9">
         <%= input f, :width %>
       </div>
     </div>
@@ -146,7 +146,7 @@
         </div>
         <div class="label-txt">Include keywords that buyers would use to search for your item.</div>
       </label>
-      <div class="col-sm-9">           
+      <div class="col-sm-9">
         <%= input f, :depth %>
       </div>
     </div>
@@ -157,7 +157,7 @@
         </div>
         <div class="label-txt">Include keywords that buyers would use to search for your item.</div>
       </label>
-      <div class="col-sm-9">           
+      <div class="col-sm-9">
         <%= input f, :depth %>
       </div>
     </div>
@@ -168,7 +168,7 @@
         </div>
         <div class="label-txt">Include keywords that buyers would use to search for your item.</div>
       </label>
-      <div class="col-sm-9">           
+      <div class="col-sm-9">
         <%= input f, :weight %>
       </div>
     </div>
@@ -180,7 +180,7 @@
     </div>
     <% end %>
   </div>
-  <%= if  @conn.request_path != product_path(@conn, :new) and has_themes(@parent_product) do %>
+  <%= if  @conn.request_path != product_path(@conn, :new) and can_add_variant(@parent_product) do %>
   <div class="tab-pane fade" id="tab2default" >
     <div style="background: #f8f9fa;">
       <div class="form-group required">
@@ -308,7 +308,7 @@
           </div>
           <div class="label-txt">Include keywords that buyers would use to search for your item.</div>
         </label>
-        <div class="col-sm-9">           
+        <div class="col-sm-9">
           <%= select :stock, :location_id, get_stock_locations_option(@stock_locations), class: "form-control"%>
         </div>
       </div>
@@ -319,7 +319,7 @@
           </div>
           <div class="label-txt">Include keywords that buyers would use to search for your item.</div>
         </label>
-        <div class="col-sm-9">           
+        <div class="col-sm-9">
           <%= text_input :stock, :count_on_hand , class: "form-control"%>
         </div>
       </div>

--- a/apps/admin_app/lib/admin_app_web/views/product_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/product_view.ex
@@ -1,6 +1,8 @@
 defmodule AdminAppWeb.ProductView do
   use AdminAppWeb, :view
   alias Snitch.Data.Model.Product
+  alias Snitch.Data.Schema.Variation
+  alias Snitch.Repo
   import Ecto.Query
 
   @currencies ["USD", "INR"]
@@ -10,34 +12,44 @@ defmodule AdminAppWeb.ProductView do
     image.url
   end
 
-  def themes_options(parent_product) do
-    Enum.map(parent_product.taxon.variation_themes, fn theme -> {theme.name, theme.id} end)
+  def themes_options(product) do
+    Enum.map(product.taxon.variation_themes, fn theme -> {theme.name, theme.id} end)
   end
 
   # TODO This needs to be replaced and we need a better system to identify
   # the type of product.
   def is_parent_product(product_id) when is_binary(product_id) do
-    q =
+    query =
       from(
         p in "snitch_product_variants",
         where: p.parent_product_id == ^(product_id |> String.to_integer()),
         select: fragment("count(*)")
       )
 
-    count = Snitch.Repo.one(q)
+    count = Snitch.Repo.one(query)
     count > 0
   end
 
-  def has_themes(parent_product) do
-    length(parent_product.taxon.variation_themes) > 0
+  def can_add_variant(product) do
+    has_themes(product) && !is_child_product(product)
   end
 
-  def has_variants(parent_product) do
-    parent_product.variants |> length > 0
+  def has_themes(product) do
+    length(product.taxon.variation_themes) > 0
   end
 
-  def get_option_types(parent_product) do
-    variant = parent_product.variants |> List.first()
+  defp is_child_product(product) do
+    query = from(c in Variation, where: c.child_product_id == ^product.id)
+    count = Repo.aggregate(query, :count, :id)
+    count > 0
+  end
+
+  def has_variants(product) do
+    product.variants |> length > 0
+  end
+
+  def get_option_types(product) do
+    variant = product.variants |> List.first()
 
     variant.options
     |> Enum.map(fn x -> x.option_type end)


### PR DESCRIPTION
Hide variants tab for child product edit page.
<!--- Provide a general summary of your changes in the Title above -->
<!--- in NOT MORE THAN 50 characters. Keep it short, pls. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->
Since child_products don't have variants, hence, there's no need to show variants for a child product. 

## Describe your changes
<!--- List and detail all changes made in this PR. -->
Variants tab made to appear on edit product page only if it is a parent product. Child products can't have variants any further.

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
