### PR TITLE
Restrict variation theme create without option type

### DIFF
--- a/apps/admin_app/lib/admin_app_web/views/input_helpers.ex
+++ b/apps/admin_app/lib/admin_app_web/views/input_helpers.ex
@@ -49,7 +49,12 @@ defmodule AdminAppWeb.InputHelpers do
   end
 
   def multi_select(form, field, list, name \\ nil, opts \\ []) do
-    input_opts = [class: "full-width w-100", "data-init-plugin": "select2"] ++ opts
+    input_opts =
+      [
+        class: "full-width w-100 form-control #{state_class(form, field)}",
+        "data-init-plugin": "select2"
+      ] ++ opts
+
     input = Form.multiple_select(form, field, list, input_opts)
     hidden_input = hidden_input(form, field, value: "")
     base_input(form, field, name, [hidden_input, input])

--- a/apps/snitch_core/lib/core/data/schema/variation_theme.ex
+++ b/apps/snitch_core/lib/core/data/schema/variation_theme.ex
@@ -27,7 +27,7 @@ defmodule Snitch.Data.Schema.VariationTheme do
     timestamps()
   end
 
-  @create_params ~w(name)a
+  @create_params ~w(name option_type_ids)a
 
   @doc """
   Returns a changeset to create new Variation theme
@@ -52,12 +52,16 @@ defmodule Snitch.Data.Schema.VariationTheme do
     |> put_assoc_option_types(params["option_type_ids"])
   end
 
-  defp put_assoc_option_types(changeset, option_type) when option_type in [nil, ""] do
+  defp put_assoc_option_types(changeset, option_type) when option_type == nil do
     option_type_ids = Enum.map(changeset.data.option_types, & &1.id)
 
     changeset
     |> put_change(:option_type_ids, option_type_ids)
     |> put_assoc(:option_types, Enum.map([], &change/1))
+  end
+
+  defp put_assoc_option_types(changeset, option_type) when option_type == "" do
+    changeset
   end
 
   defp put_assoc_option_types(changeset, option_types) do


### PR DESCRIPTION
Show form error on providing invalid option types as input.

<!--- Provide a general summary of your changes in the Title above -->
<!--- in NOT MORE THAN 50 characters. Keep it short, pls. -->

## Motivation and Context
Since the form was accepting nil/empty values for option types in variation theme creation, so, that had to be handled.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## Describe your changes
<!--- List and detail all changes made in this PR. -->
Minor tweaks in multi-select form input helper to show error on invalid input.

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
