### PR TITLE
[API] Fix errors for same user signup

### DIFF
--- a/apps/admin_app/assets/package.json
+++ b/apps/admin_app/assets/package.json
@@ -6,7 +6,7 @@
     "watch": "brunch watch --stdin"
   },
   "dependencies": {
-    "bootstrap": "^4.1.2",
+    "bootstrap": "4.1.2",
     "elm": "^0.18.0",
     "elm-brunch": "^0.11.1",
     "font-awesome": "^4.7.0",

--- a/apps/admin_app/assets/yarn.lock
+++ b/apps/admin_app/assets/yarn.lock
@@ -726,9 +726,9 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bootstrap@^4.1.2:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.3.tgz#0eb371af2c8448e8c210411d0cb824a6409a12be"
+bootstrap@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-4.1.2.tgz#aee2a93472e61c471fc79fb475531dcbc87de326"
 
 bower-config@^1.4.0:
   version "1.4.1"

--- a/apps/snitch_core/lib/core/data/schema/user.ex
+++ b/apps/snitch_core/lib/core/data/schema/user.ex
@@ -86,6 +86,7 @@ defmodule Snitch.Data.Schema.User do
   @spec common_changeset(Ecto.Changeset.t()) :: Ecto.Changeset.t()
   defp common_changeset(user_changeset) do
     user_changeset
+    |> unique_constraint(:email, message: "This email is already registered")
     |> foreign_key_constraint(:role_id)
     |> validate_confirmation(:password)
     |> validate_length(:password, min: @password_min_length)


### PR DESCRIPTION
Fix the issues where the API would break when already signed-up user signup again.

## Motivation and Context
Signup API was breaking for same email signup.

## Describe your changes
`core`
--------
- Added check for duplicate email in changeset.

`admin_app`
-----------------
- Fixes vulnerability issue raised by Github for bootstrap version `4.1.1`. Update the version to `4.1.2`

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
