### PR TITLE
Using precompiled email template

### DIFF
--- a/apps/snitch_core/lib/core/tools/mailer/email_templates/order_confirmation_email.html.eex
+++ b/apps/snitch_core/lib/core/tools/mailer/email_templates/order_confirmation_email.html.eex
@@ -3,7 +3,7 @@
 
     <p>Please review and retain the following order information for your records.</p>
    
-    <p>Order #<%= order.id %> Summary</p>
+    <p>Order #<%= @order.id %> Summary</p>
 
     <b> Order items list </b>:
     <table class="table">
@@ -15,7 +15,7 @@
         </tr>
     </thead>
    <tbody>
-    <%= for line_item <- order.line_items do %>
+    <%= for line_item <- @order.line_items do %>
         <tr>
             <td><%= line_item.product.sku %></td>
             <td><%= line_item.quantity %></td>

--- a/apps/snitch_core/lib/core/tools/mailer/order_confirmation_email.ex
+++ b/apps/snitch_core/lib/core/tools/mailer/order_confirmation_email.ex
@@ -2,21 +2,32 @@ defmodule Snitch.Tools.OrderEmail do
   @moduledoc """
   Composing email to send order confirmation mail.
   """
-  use Bamboo.EEx, path: Path.join([File.cwd!(), "lib/core/tools/mailer/email_templates"])
+  use Bamboo.EEx
   alias Snitch.Tools.Mailer
   alias Snitch.Repo
+  require EEx
+
+  email_template =
+    Path.join([
+      File.cwd!(),
+      "lib/core/tools/mailer/email_templates/order_confirmation_email.html.eex"
+    ])
+
+  EEx.function_from_file(:defp, :order_email, email_template, [:assigns])
 
   def order_confirmation_mail(order) do
     sender_email = Application.get_env(:snitch_core, Snitch.Tools.Mailer)[:sendgrid_sender_mail]
     order = Repo.preload(order, [:user, line_items: :product])
+
     user_email = order.user.email
+    mail_template = order_email(%{order: order})
 
     new_email()
     |> to(user_email)
     |> from({"Snitch", sender_email})
     |> subject("Order Confirmation - Your Order with Snitch has been successfully placed!
             ")
-    |> render_to_html("order_confirmation_email.html.eex", %{order: order})
+    |> html_body(mail_template)
     |> Mailer.deliver_now()
   end
 end


### PR DESCRIPTION
Precompiling order confirmation mail template inside the module.

<!--- Provide a general summary of your changes in the Title above -->
<!--- in NOT MORE THAN 50 characters. Keep it short, pls. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->
Was not able to fetch the order confirmation template on production since it happens on runtime. Hence, using the precompiled template for sending order confirmation emails.

## Describe your changes
<!--- List and detail all changes made in this PR. -->
Used Embedded Elixir(EEx) that allows embedding Elixir code(order confirmation email template in this case) inside a string in a robust way so that it gets precompiled in the module itself .



## Any further comments?

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
