### PR TITLE
Product orderable state in API response

### DIFF
--- a/apps/snitch_api/lib/snitch_api_web/views/product_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/product_view.ex
@@ -19,7 +19,8 @@ defmodule SnitchApiWeb.ProductView do
     :selling_price,
     :max_retail_price,
     :images,
-    :rating_summary
+    :rating_summary,
+    :is_orderable
   ])
 
   def selling_price(product) do
@@ -39,6 +40,10 @@ defmodule SnitchApiWeb.ProductView do
 
   def rating_summary(product, _conn) do
     ProductReview.review_aggregate(product)
+  end
+
+  def is_orderable(product, _conn) do
+    Product.is_orderable?(product)
   end
 
   has_one(

--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -249,4 +249,28 @@ defmodule Snitch.Data.Model.Product do
       Map.put(acc, v_id, sp)
     end)
   end
+
+  @doc """
+  Ordering of product depends on many things, for now we just check
+  sufficient stock is available.
+  """
+  def is_orderable?(product) do
+    has_stock?(product)
+  end
+
+  defp has_stock?(product) do
+    product = Repo.preload(product, :stock_items)
+
+    case product.stock_items do
+      [] ->
+        false
+
+      stock ->
+        total_count_on_hand(stock) > 0
+    end
+  end
+
+  defp total_count_on_hand(stocks) do
+    Enum.reduce(stocks, 0, fn stock, acc -> stock.count_on_hand + acc end)
+  end
 end


### PR DESCRIPTION
Add `is_orderable` field to product json response.

## Motivation and Context
Frontend should be able to identify whether a product can be purchased or not before adding to cart.

## Describe your changes
- Changes API response to send orderable state of product.

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
