### PR TITLE
Add Image url in API response for taxon 

### DIFF
--- a/apps/admin_app/lib/admin_app_web/templates/taxonomy/list.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/taxonomy/list.html.eex
@@ -4,9 +4,9 @@
     <div class="taxon-actions float-right">
       <i class="add-taxon fa fa-plus-square fa-4" aria-hidden="true"></i>
       <i class="edit-taxon fa fa-pencil-square fa-4" aria-hidden="true"></i>
-      <%= if !is_root(@taxonomy) do %>
+      <!-- <%= if !is_root(@taxonomy) do %>
       <i class="fa fa-trash fa-4" aria-hidden="true"></i>
-      <% end %>
+      <% end %> -->
     </div>
   </span>
   <%= if has_children(@taxonomy) do %>

--- a/apps/snitch_core/lib/core/tools/helpers/taxonomy.ex
+++ b/apps/snitch_core/lib/core/tools/helpers/taxonomy.ex
@@ -66,6 +66,18 @@ defmodule Snitch.Tools.Helper.Taxonomy do
     }
   end
 
+  def image_url(taxon) do
+    taxon = Repo.preload(taxon, taxon_image: :image)
+
+    case taxon.taxon_image do
+      nil ->
+        nil
+
+      _ ->
+        TaxonomyDomain.image_url(taxon.taxon_image.image.name, taxon)
+    end
+  end
+
   def convert_taxon([]) do
     []
   end
@@ -78,6 +90,7 @@ defmodule Snitch.Tools.Helper.Taxonomy do
       permlink: "",
       parent_id: taxon.parent_id,
       taxonomy_id: taxon.taxonomy_id,
+      image_url: image_url(taxon),
       taxons: Enum.map(children, &convert_taxon/1)
     }
   end


### PR DESCRIPTION
Add image URL in API response for taxon and disable delete for taxon.

## Motivation and Context
Front store needs to display images for category, so image_url was needed in API.

## Describe your changes
`snitch_api`
- Add `image_url` in taxon response.
- Disable taxon delete

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
