### PR TITLE
[Admin] Order detail page was not viewable for order with multiple items.

### DIFF
--- a/apps/admin_app/lib/admin_app_web/templates/order/show.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/order/show.html.eex
@@ -23,7 +23,7 @@
                     <div class="orderon">Ordered <%= format_date(@order.updated_at) %></div>
                     <div class="orderon">Ship to <%= get_country_state(@order) %></div>
                 </div>
-              </div>             
+              </div>
             </div>
          </div>
          <div class="my-3 order-btns">
@@ -75,7 +75,7 @@
                <a class="btn btn-primary float-right " style="width: 100px;" href="/orders/<%= @order.number %>/show-packing-slip">Show</a>
             </div>
          </div>
-         <h3 class="mt-3">Shipping Details afasf</h3>
+         <h3 class="mt-3">Shipping Details</h3>
          <div class="card col-12">
             <div class="row">
                <div class="col-4">

--- a/apps/admin_app/lib/admin_app_web/views/order_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/order_view.ex
@@ -26,7 +26,7 @@ defmodule AdminAppWeb.OrderView do
         "1 item"
 
       items ->
-        items <> " items"
+        Integer.to_string(items) <> " items"
     end
   end
 


### PR DESCRIPTION
FIx issue where order detail page cannot be viewed when order had multiple items.

Fixes : [Sentry Issue](https://sentry.io/share/issue/36a5c96c1def4564beb38dfb5961494e/)

## Motivation and Context
- Order detail page was not visible when order had more than one item.

## Describe your changes
- Changed order view method to convert the integer value to string for the item count.

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
