### PR TITLE
Hide sendgrid api key field

### DIFF
--- a/apps/admin_app/lib/admin_app_web/controllers/general_settings_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/general_settings_controller.ex
@@ -37,9 +37,7 @@ defmodule AdminAppWeb.GeneralSettingsController do
         handle_nil_response(conn)
 
       _ ->
-        map =
-          general_configuration
-          |> Map.from_struct()
+        map = Map.replace!(Map.from_struct(general_configuration), :sendgrid_api_key, nil)
 
         changeset = GCModel.build_general_configuration(map)
 

--- a/apps/admin_app/lib/admin_app_web/templates/general_settings/index.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/general_settings/index.html.eex
@@ -31,10 +31,6 @@
         <td><%= @general_configuration.sender_mail %></td>
       </tr> 
       <tr>
-        <td><b>SENDGRID_API_KEY</b></td> 
-        <td><%= @general_configuration.sendgrid_api_key %></td>
-      </tr> 
-      <tr>
         <td><b>CURRENCY</b></td> 
         <td><%= @general_configuration.currency %></td>
       </tr>


### PR DESCRIPTION
Deletion of sendgrid API key from show general settings page and showing it as blank on edit configuration form. 

<!--- Provide a general summary of your changes in the Title above -->
<!--- in NOT MORE THAN 50 characters. Keep it short, pls. -->

## Motivation and Context
Keeping in consideration the privacy concerns, we need to restrict the access to sendgrid API key from public.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## Describe your changes
- Removed the API key section from show general settings page.
- Keeping the API key field as blank on edit general settings form.
<!--- List and detail all changes made in this PR. -->

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
