### PR TITLE
Handle error while stock addition

### DIFF
--- a/apps/snitch_core/lib/core/data/schema/stock/stock_item.ex
+++ b/apps/snitch_core/lib/core/data/schema/stock/stock_item.ex
@@ -45,12 +45,12 @@ defmodule Snitch.Data.Schema.StockItem do
 
   defp handle_count(changeset) do
     case get_change(changeset, :count_on_hand) do
+      nil ->
+        changeset
+
       count ->
         count_on_hand = changeset.data.count_on_hand + count
         put_change(changeset, :count_on_hand, count_on_hand)
-
-      nil ->
-        changeset
     end
   end
 


### PR DESCRIPTION
Handling nil case when no stock is added on clicking "Add Stock" button. 

<!--- Provide a general summary of your changes in the Title above -->
<!--- in NOT MORE THAN 50 characters. Keep it short, pls. -->

## Motivation and Context
Since the function handle_count was failing with error on clicking "Add Stock" button when no stock item was added, therefore we need to handle the same.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## Describe your changes
<!--- List and detail all changes made in this PR. -->
Reordering function handle_count for pattern matching to handle nil case scenario first, if there is no stock item added.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
