### PR TITLE
fix default behaviour on clicking enter on form.

### DIFF
--- a/apps/admin_app/lib/admin_app_web/templates/option_type/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/option_type/form.html.eex
@@ -7,7 +7,7 @@
 </div>
 <div class="form-group row stickformbutton">
    <div class="col-sm-10">
-      <%= button("Cancel", to: option_type_path(@conn, :index), method: "get",
+      <%= button("Cancel", to: option_type_path(@conn, :index), method: "get", type: "button",
             class: "btn btn-secondary btn-outline-secondary submit-btn float-left") %>
       <%= submit "Submit", class: "btn btn-primary submit-btn float-right" %>
    </div>

--- a/apps/admin_app/lib/admin_app_web/templates/payment_method/edit.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/payment_method/edit.html.eex
@@ -26,7 +26,7 @@
       <div class="form-group row stickformbutton">
         <div class="col-sm-10">
           <%= submit "Submit", class: "btn btn-primary submit-btn float-right" %>
-          <%= link("Cancel", to: payment_method_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary float-left") %>
+          <%= link("Cancel", to: payment_method_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary float-left", type: "button") %>
         </div>
       </div>
       <% end %>

--- a/apps/admin_app/lib/admin_app_web/templates/payment_method/new.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/payment_method/new.html.eex
@@ -24,7 +24,7 @@
         <div class="form-group row stickformbutton">
           <div class="col-sm-10">
             <%= submit "Submit", class: "btn btn-primary submit-btn float-right" %>
-            <%= link("Cancel", to: payment_method_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary  float-left") %>
+            <%= link("Cancel", to: payment_method_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary  float-left", type: "button") %>
           </div>
         </div>
       </form>

--- a/apps/admin_app/lib/admin_app_web/templates/permission/_form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/permission/_form.html.eex
@@ -8,7 +8,7 @@
 <div class="form-group row stickformbutton">
   <div class="col-sm-10">
     <%= submit "Submit", class: "btn btn-primary submit-btn float-right" %>
-    <%= link("Cancel", to: permission_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary float-left") %>
+    <%= link("Cancel", to: permission_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary float-left", type: "button") %>
   </div>
 </div>
 <% end %>

--- a/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
@@ -191,7 +191,7 @@
                 <div>Add Images</div>
               </label>
               <%= file_input f, :images, multiple: true, class: "file-upload__input",
-                id: "product-images" %>
+                id: "product-images", onchange: "form.submit()" %>
             </div>
             <div id="img-selected-container" class="img-selected-container row m-0 col-12 p-0">
             </div>

--- a/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
@@ -90,7 +90,7 @@
     </div>
     <div class="form-group row stickformbutton">
       <div class="col-sm-10">
-        <%= button("Cancel", to: product_path(@conn, :index), method: "get",
+        <%= button("Cancel", to: product_path(@conn, :index), method: "get",  type: "button",
           class: "btn btn-secondary btn-outline-secondary submit-btn float-left") %>
         <%= submit "Submit", class: "btn  btn-primary submit-btn float-right" %>
       </div>
@@ -200,7 +200,7 @@
       </div>
       <div class="form-group row stickformbutton">
         <div class="col-sm-10">
-          <%= button("Cancel", to: product_path(@conn, :index), method: "get",
+          <%= button("Cancel", to: product_path(@conn, :index), method: "get", type: "button",
             class: "btn btn-secondary btn-outline-secondary submit-btn float-left") %>
           <%= submit "Submit", class: "btn  btn-primary submit-btn float-right" %>
         </div>
@@ -257,8 +257,8 @@
       </div>
       <div class="form-group row stickformbutton">
         <div class="col-sm-10">
-          <button class="btn btn-primary submit-btn float-right" type="submit">Add Stock</button>
-          <%= button("Cancel", to: product_path(@conn, :index), method: "get",
+          <%= submit "Add Stock", class: "btn  btn-primary submit-btn float-right" %>
+          <%= button("Cancel", to: product_path(@conn, :index), method: "get", type: "button",
             class: "btn btn-secondary btn-outline-secondary submit-btn float-left") %>
         </div>
       </div>

--- a/apps/admin_app/lib/admin_app_web/templates/product/property_form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/product/property_form.html.eex
@@ -9,7 +9,7 @@
   <div class="form-group row">
     <div class="col-sm-10">
       <%= submit "Submit", class: "btn btn-primary submit-btn col-2" %>
-      <%= link("Cancel", to: product_path(@conn, :index), class: "btn btn-primary col-2") %>
+      <%= link("Cancel", to: product_path(@conn, :index), class: "btn btn-primary col-2", type: "button") %>
     </div>
   </div>
 </form>

--- a/apps/admin_app/lib/admin_app_web/templates/product_brand/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/product_brand/form.html.eex
@@ -17,7 +17,7 @@
 <div class="form-group row stickformbutton">
   <div class="col-sm-10">
     <%= submit "Submit", class: "btn btn-primary submit-btn float-right" %>
-    <%= link("Cancel", to: product_brand_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary float-left") %>
+    <%= link("Cancel", to: product_brand_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary float-left", type: "button") %>
   </div>
 </div>
 <% end %>

--- a/apps/admin_app/lib/admin_app_web/templates/property/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/property/form.html.eex
@@ -7,7 +7,7 @@
 </div>
 <div class="form-group row stickformbutton">
   <div class="col-sm-10">
-    <%= button("Cancel", to: property_path(@conn, :index), method: "get",
+    <%= button("Cancel", to: property_path(@conn, :index), method: "get", type: "button",
       class: "btn btn-secondary btn-outline-secondary submit-btn float-left") %>
     <%= submit "Submit", class: "btn btn-primary submit-btn float-right" %>
   </div>

--- a/apps/admin_app/lib/admin_app_web/templates/prototype/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/prototype/form.html.eex
@@ -14,7 +14,7 @@
 <div class="form-group row stickformbutton">
    <div class="col-sm-10">
      <%= button("Cancel", to: prototype_path(@conn, :index), method: "get",
-            class: "btn btn-secondary btn-outline-secondary submit-btn float-left") %>
+            class: "btn btn-secondary btn-outline-secondary submit-btn float-left", type: "button") %>
       <%= submit "Submit", class: "btn btn-primary submit-btn float-right" %>
    </div>
 </div>

--- a/apps/admin_app/lib/admin_app_web/templates/role/_form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/role/_form.html.eex
@@ -20,7 +20,7 @@
 <div class="form-group row stickformbutton">
    <div class="col-sm-10">
       <%= submit "Submit", class: "btn btn-primary submit-btn float-right" %>
-      <%= link("Cancel", to: role_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary float-left") %>
+      <%= link("Cancel", to: role_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary float-left", type: "button") %>
    </div>
 </div>
 <% end %>

--- a/apps/admin_app/lib/admin_app_web/templates/role/edit.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/role/edit.html.eex
@@ -26,7 +26,7 @@
   <div class="form-group row stickformbutton">
     <div class="col-sm-10">
       <%= submit "Submit", class: "btn btn-primary submit-btn float-right" %>
-      <%= link("Cancel", to: role_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary float-left") %>
+      <%= link("Cancel", to: role_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary float-left", type: "button") %>
     </div>
   </div>
   <% end %>

--- a/apps/admin_app/lib/admin_app_web/templates/stock_location/_form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/stock_location/_form.html.eex
@@ -38,7 +38,7 @@
 <div class="form-group row stickformbutton">
   <div class="col-sm-10">
     <%= button("Cancel", to: stock_location_path(@conn, :index), method: "get",
-            class: "btn btn-secondary btn-outline-secondary submit-btn float-left") %>
+            class: "btn btn-secondary btn-outline-secondary submit-btn float-left", type: "button") %>
     <%= submit "Submit", class: "btn btn-primary submit-btn float-right" %>
   </div>
 </div>

--- a/apps/admin_app/lib/admin_app_web/templates/user/_form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/user/_form.html.eex
@@ -21,7 +21,7 @@
 <div class="form-group row stickformbutton">
   <div class="col-sm-10">
     <%= submit "Submit", class: "btn btn-primary submit-btn float-right" %>
-    <%= link("Cancel", to: user_path(@conn, :index), class: "btn  btn-secondary btn-outline-secondary float-left") %>
+    <%= link("Cancel", to: user_path(@conn, :index), class: "btn  btn-secondary btn-outline-secondary float-left", type: "button") %>
   </div>
 </div>
 <% end %>

--- a/apps/admin_app/lib/admin_app_web/templates/variation_theme/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/variation_theme/form.html.eex
@@ -7,7 +7,7 @@
 </div>
 <div class="form-group row stickformbutton">
   <div class="col-sm-10">
-    <%= button("Cancel", to: variation_theme_path(@conn, :index), method: "get",
+    <%= button("Cancel", to: variation_theme_path(@conn, :index), method: "get", type: "button",
         class: "btn btn-secondary btn-outline-secondary submit-btn float-left") %>
      <%= submit "Submit", class: "btn btn-primary submit-btn float-right" %>
   </div>

--- a/apps/admin_app/lib/admin_app_web/templates/zone/edit.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/zone/edit.html.eex
@@ -53,7 +53,7 @@
          <div class="form-group row stickformbutton">
             <div class="col-sm-10">
                <%= submit "Submit", class: "btn btn-primary submit-btn float-right" %>
-               <%= link("Cancel", to: zone_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary float-left") %>
+               <%= link("Cancel", to: zone_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary float-left", type: "button") %>
             </div>
          </div>
          </form>

--- a/apps/admin_app/lib/admin_app_web/templates/zone/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/zone/form.html.eex
@@ -44,7 +44,7 @@
 <div class="form-group row stickformbutton">
    <div class="col-sm-10">
       <%= submit "Submit", class: "btn btn-primary submit-btn float-right"%>
-      <%= link("Cancel", to: zone_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary float-left") %>
+      <%= link("Cancel", to: zone_path(@conn, :index), class: "btn btn-secondary btn-outline-secondary float-left", type: "button") %>
    </div>
 </div>
 </form>


### PR DESCRIPTION
Submitting the forms on clicking enter throughout the app wherever form is used.

<!--- Provide a general summary of your changes in the Title above -->
<!--- in NOT MORE THAN 50 characters. Keep it short, pls. -->

## Motivation and Context
To preserve the normal behaviour of form and submitting it on clicking enter button. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## Describe your changes
<!--- List and detail all changes made in this PR. -->
Assigned type-"button" to the **cancel button** in the forms since it otherwise took "submit" as it's type by default and we have separate **submit button** for that with the type "submit".

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
