### PR TITLE
Fix template errors while new product creation.

### DIFF
--- a/apps/admin_app/lib/admin_app_web/controllers/product_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/product_controller.ex
@@ -20,7 +20,7 @@ defmodule AdminAppWeb.ProductController do
   alias Snitch.Data.Model.StockItem, as: StockModel
   alias Snitch.Data.Schema.StockItem, as: StockSchema
 
-  plug(:load_resources when action in [:new, :edit])
+  plug(:load_resources when action in [:new, :edit, :create])
 
   @rummage_default %{
     "rummage" => %{
@@ -53,6 +53,7 @@ defmodule AdminAppWeb.ProductController do
       redirect(conn, to: product_path(conn, :edit, product.id))
     else
       {:error, changeset} ->
+        conn = %{conn | request_path: product_path(conn, :new)}
         render(conn, "new.html", changeset: %{changeset | action: :new})
     end
   end


### PR DESCRIPTION
Redirecting to new product create page with changeset errors to be shown on form and fixing template errors.

## Motivation and Context
While creating a new product if there are any errors, those have to be properly rendered on the product create form.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## Describe your changes
<!--- List and detail all changes made in this PR. -->
Changed the request path in conn object while rendering add product form after submitting it with invalid data since the template has the condition checking the request path and rendering the html accordingly.

Fixes issues for [#161336309](https://www.pivotaltracker.com/story/show/161336309)
------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
