### PR TITLE
Show product category on product create page

### DIFF
--- a/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
@@ -1,3 +1,9 @@
+<%= if  @conn.request_path == product_path(@conn, :new) do %>
+  <div style="margin-bottom:1rem">
+    <span>Product Category </span>
+    <span class="badge badge-secondary"><%= get_product_category(@conn) %></span>
+  </div>
+<% end %>
 <ul class="nav nav-tabs">
    <li class="nav-item">
       <a class="nav-link active" href="#tab1default" data-toggle="tab">Product Detail</a>

--- a/apps/snitch_core/lib/core/domain/taxonomy/taxonomy.ex
+++ b/apps/snitch_core/lib/core/domain/taxonomy/taxonomy.ex
@@ -142,6 +142,21 @@ defmodule Snitch.Domain.Taxonomy do
     Repo.all(from(taxon in Taxon, where: taxon.parent_id == ^taxon_id))
   end
 
+  def get_ancestors(taxon_id) do
+    case Repo.get(Taxon, taxon_id) do
+      nil ->
+        {:error, :not_found}
+
+      taxon ->
+        ancestors =
+          taxon
+          |> AsNestedSet.ancestors()
+          |> AsNestedSet.execute(Repo)
+
+        {:ok, ancestors}
+    end
+  end
+
   @doc """
   Get taxon by id
   """


### PR DESCRIPTION
Selected product category is displayed on product create page.

## Motivation and Context
There was no indication about the selected category on product create page.

## Describe your changes
`admin_app`
----------------
- changed template and view for displaying the category.

`core`
-------
- Added method to get ancestor list of particulat category. 

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
