### PR TITLE
fix product listing for active products

### DIFF
--- a/apps/admin_app/lib/admin_app_web/controllers/session_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/session_controller.ex
@@ -135,7 +135,7 @@ defmodule AdminAppWeb.SessionController do
     conn
     |> Plug.sign_in(user)
     |> put_flash(:info, "You are logged in!")
-    |> redirect(to: dashboard_path(conn, :index))
+    |> redirect(to: dashboard_path(conn, :index, from: date_days_before(30), to: date_today()))
   end
 
   defp login({:error, _}, conn) do

--- a/apps/admin_app/lib/admin_app_web/helpers.ex
+++ b/apps/admin_app/lib/admin_app_web/helpers.ex
@@ -51,4 +51,15 @@ defmodule AdminAppWeb.Helpers do
   defp select_date(today, ""), do: today
 
   defp select_date(_today, date_from_params), do: date_from_params
+
+  def date_today() do
+    Date.utc_today()
+    |> Date.to_string()
+  end
+
+  def date_days_before(days) do
+    Date.utc_today()
+    |> Date.add(-1 * days)
+    |> Date.to_string()
+  end
 end

--- a/apps/admin_app/lib/admin_app_web/templates/layout/sidebar.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/layout/sidebar.html.eex
@@ -13,7 +13,7 @@
     </div>
   </li>
   <li>
-    <a class="nav-link" href=<%= "/dashboard?from=#{date_days_before(30)}&to=#{date_today()}" %>>
+    <a class="nav-link" href=<%= "/dashboard?from=#{Helpers.date_days_before(30)}&to=#{Helpers.date_today()}" %>>
     <i class="fa fa-clipboard-list" aria-hidden="true"></i> <span> Dashboard</span>
     </a>
   </li>

--- a/apps/admin_app/lib/admin_app_web/templates/layout/sidebar.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/layout/sidebar.html.eex
@@ -13,7 +13,7 @@
     </div>
   </li>
   <li>
-    <a class="nav-link" href="/dashboard">
+    <a class="nav-link" href=<%= "/dashboard?from=#{date_days_before(30)}&to=#{date_today()}" %>>
     <i class="fa fa-clipboard-list" aria-hidden="true"></i> <span> Dashboard</span>
     </a>
   </li>

--- a/apps/admin_app/lib/admin_app_web/views/layout_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/layout_view.ex
@@ -3,6 +3,7 @@ defmodule AdminAppWeb.LayoutView do
   alias AdminAppWeb.Guardian
   alias Snitch.Data.Schema.{GeneralConfiguration, Taxonomy}
   alias Snitch.Core.Tools.MultiTenancy.Repo
+  alias AdminAppWeb.Helpers
 
   @doc """
   Generates name for the JavaScript view we want to use
@@ -45,16 +46,5 @@ defmodule AdminAppWeb.LayoutView do
   def get_user_name(conn) do
     user = conn.private.guardian_default_resource
     "#{user.first_name} #{user.last_name}"
-  end
-
-  def date_days_before(days) do
-    Date.utc_today()
-    |> Date.add(-1 * days)
-    |> Date.to_string()
-  end
-
-  def date_today() do
-    Date.utc_today()
-    |> Date.to_string()
   end
 end

--- a/apps/admin_app/lib/admin_app_web/views/layout_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/layout_view.ex
@@ -46,4 +46,15 @@ defmodule AdminAppWeb.LayoutView do
     user = conn.private.guardian_default_resource
     "#{user.first_name} #{user.last_name}"
   end
+
+  def date_days_before(days) do
+    Date.utc_today()
+    |> Date.add(-1 * days)
+    |> Date.to_string()
+  end
+
+  def date_today() do
+    Date.utc_today()
+    |> Date.to_string()
+  end
 end

--- a/apps/admin_app/lib/admin_app_web/views/product_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/product_view.ex
@@ -218,7 +218,7 @@ defmodule AdminAppWeb.ProductView do
 
     with %Taxon{} = taxon <- Repo.get(Taxon, taxon_id),
          {:ok, ancestors} <- Taxonomy.get_ancestors(taxon_id) do
-      ancestors ++ [taxon]
+      (ancestors ++ [taxon])
       |> generate_taxon_text("")
     else
       _ ->

--- a/apps/snitch_api/lib/snitch_api/products_context/products_context.ex
+++ b/apps/snitch_api/lib/snitch_api/products_context/products_context.ex
@@ -11,7 +11,7 @@ defmodule SnitchApi.ProductsContext do
   List out all the products
   """
   def list_products(conn, params) do
-    #TODO Here we are skipping the products that are child product but
+    # TODO Here we are skipping the products that are child product but
     # this can be easily handled by product types once it is introduced
     child_product_ids = from(c in Variation, select: c.child_product_id) |> Repo.all()
 

--- a/apps/snitch_api/lib/snitch_api/products_context/products_context.ex
+++ b/apps/snitch_api/lib/snitch_api/products_context/products_context.ex
@@ -16,7 +16,7 @@ defmodule SnitchApi.ProductsContext do
     child_product_ids = from(c in Variation, select: c.child_product_id) |> Repo.all()
 
     query = define_query(params)
-    query = from(p in query, where: p.is_active == true and p.id not in ^child_product_ids)
+    query = from(p in query, where: p.state == "active" and p.id not in ^child_product_ids)
 
     page = create_page(query, %{}, conn)
     products = paginate_collection(query, params)

--- a/apps/snitch_api/test/snitch_api_web/controllers/product_controller_test.exs
+++ b/apps/snitch_api/test/snitch_api_web/controllers/product_controller_test.exs
@@ -90,8 +90,6 @@ defmodule SnitchApiWeb.ProductControllerTest do
       json_response(conn, 200)["data"]
       |> List.first()
 
-    require IEx
-    IEx.pry()
     assert response["attributes"]["name"] == product.name
   end
 end

--- a/apps/snitch_api/test/snitch_api_web/controllers/product_controller_test.exs
+++ b/apps/snitch_api/test/snitch_api_web/controllers/product_controller_test.exs
@@ -31,7 +31,7 @@ defmodule SnitchApiWeb.ProductControllerTest do
   end
 
   test "Products in Descending Order", %{conn: conn} do
-    product = insert(:product)
+    product = insert(:product, %{state: "active"})
 
     params = %{"sort" => "Z-A"}
 
@@ -45,7 +45,7 @@ defmodule SnitchApiWeb.ProductControllerTest do
   end
 
   test "Products in Ascending Order", %{conn: conn} do
-    product = insert(:product)
+    product = insert(:product, %{state: "active"})
 
     params = %{"sort" => "A-Z"}
 
@@ -59,9 +59,9 @@ defmodule SnitchApiWeb.ProductControllerTest do
   end
 
   test "Products, search contains name and pagination", %{conn: conn} do
-    product1 = insert(:product)
-    product2 = insert(:product)
-    product3 = insert(:product)
+    product1 = insert(:product, %{state: "active"})
+    product2 = insert(:product, %{state: "active"})
+    product3 = insert(:product, %{state: "active"})
 
     params = %{
       "filter" => %{"name" => "product"},
@@ -78,7 +78,7 @@ defmodule SnitchApiWeb.ProductControllerTest do
   end
 
   test "Products, sort by newly inserted", %{conn: conn} do
-    product = insert(:product)
+    product = insert(:product, %{state: "active"})
 
     params = %{
       "sort" => "date"
@@ -90,6 +90,8 @@ defmodule SnitchApiWeb.ProductControllerTest do
       json_response(conn, 200)["data"]
       |> List.first()
 
+    require IEx
+    IEx.pry()
     assert response["attributes"]["name"] == product.name
   end
 end


### PR DESCRIPTION
Return `active` product for product listing API and fix dashboard link for dates.

## Motivation and Context
- Product state was not considered while fetching the product for listing API.
- Dashboard did not show data as dates were not present in the link.

## Describe your changes
`api_app`
---------------
- Fix product listing API query to return `active` products.

`admin_app`
-----------------
- Fix the dashboard link for dates.

## Any further comments?

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
