### PR TITLE
fix brand image url in brands API

### DIFF
--- a/apps/snitch_api/lib/snitch_api_web/views/product_brand_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/product_brand_view.ex
@@ -9,6 +9,12 @@ defmodule SnitchApiWeb.ProductBrandView do
   ])
 
   def image_url(brand, conn) do
-    ProductBrand.image_url(brand.image.name, brand)
+    case brand.image do
+      nil ->
+        nil
+
+      _ ->
+        ProductBrand.image_url(brand.image.name, brand)
+    end
   end
 end


### PR DESCRIPTION
Brands API would fail when an image is not associated with the brand.

Fixes [Sentry Issue - 767816905](https://sentry.io/share/issue/6f8253a8cf0143b1bd9c1a3a6b234c3c/)

## Motivation and Context
- Brands API would fail.

## Describe your changes
`api_app`
- Handle image nil case

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
