### PR TITLE
Show variation tab for product

### DIFF
--- a/apps/admin_app/assets/js/views/taxonomy/taxonomy.js
+++ b/apps/admin_app/assets/js/views/taxonomy/taxonomy.js
@@ -1,173 +1,203 @@
-import MainView from '../main';
-import select2Selector from './../../form-helpers/select2-selector';
+import MainView from "../main";
+import select2Selector from "./../../form-helpers/select2-selector";
 
 export default class View extends MainView {
-    mount() {
-      super.mount();
+  mount() {
+    super.mount();
 
-      let children_ul = null
+    let children_ul = null;
 
-      $(".taxonomy").on("click", ".edit-taxon", function(e){
-        $("#edittaxon-modal").modal({show: true})
-        var name = $(this).closest('table').siblings('.taxon_name').text();
-        var id = $(this).closest('li').data("taxon_id");
-        $(`#taxon-edit-loader`).addClass(`loader`).show();
-        e.stopPropagation();
-        fetch('/api/taxon/' + id)
+    $(".taxonomy").on("click", ".edit-taxon", function(e) {
+      $("#edittaxon-modal").modal({ show: true });
+      var name = $(this)
+        .closest("table")
+        .siblings(".taxon_name")
+        .text();
+      var id = $(this)
+        .closest("li")
+        .data("taxon_id");
+      $(`#taxon-edit-loader`)
+        .addClass(`loader`)
+        .show();
+      e.stopPropagation();
+      fetch("/api/taxon/" + id)
         .then(function(response) {
-          return response.json()
+          return response.json();
         })
         .then(function(json) {
           $(`#taxon-edit-body`)
-          .empty()
-          .append(json.html)
-          $(`#taxon-edit-loader`).removeClass(`loader`).hide();
-          select2Selector()
-        })
-      })
+            .empty()
+            .append(json.html);
+          $(`#taxon-edit-loader`)
+            .removeClass(`loader`)
+            .hide();
+          select2Selector();
+        });
+    });
 
-      $(".taxonomy")
-        .on("click", ".add-taxon", function(e){
-        $("#taxon-modal").modal({show: true});
-        $('.modal-body select').val('').trigger("change");
-        $(".modal-body input[type=text], input[type=file]").val("");
-        var id = $(this).closest('li').data("taxon_id");
-        let chidren_selector = `ul[data-parent_id="` + id +`"]`;
-        children_ul = $(chidren_selector)
-        $("#form-taxon-id").val(id);
-        e.stopPropagation();
-      })
+    $(".taxonomy").on("click", ".add-taxon", function(e) {
+      $("#taxon-modal").modal({ show: true });
+      $(".modal-body select")
+        .val("")
+        .trigger("change");
+      $(".modal-body input[type=text], input[type=file]").val("");
+      var id = $(this)
+        .closest("li")
+        .data("taxon_id");
+      let chidren_selector = `ul[data-parent_id="` + id + `"]`;
+      children_ul = $(chidren_selector);
+      $("#form-taxon-id").val(id);
+      e.stopPropagation();
+    });
 
-      $(".taxonform").on("submit", function(event) {
-        event.preventDefault();
-        var tid = $("#form-taxon-id").val();
-        let target_div = $(`.item[data-taxon_id=${tid}]`);
-        var form_data = new FormData();
-        var image_file =  $(this).find('input[name="taxon[image]"]')[0].files[0];
-        var name = $(this).find('input[name="taxon[name]"]').val();
-        var themes = $("#taxons_taxons").val();
-        var csrf = $( this ).find( 'input:hidden' ).val();
-        form_data.append('image', image_file);
-        form_data.append('name', name);
-        form_data.append('themes', themes);
-        form_data.append('_csrf_token', csrf);
-        form_data.append('id', tid);
-        $.ajax({
-          url: '/taxonomy',
-          type: "POST",
-          data: form_data,
-          processData: false,
-          contentType: false,
-          success: function(result) {
-            $("#taxon-modal").modal('hide');
-            $(result.html)
+    $(".taxonform").on("submit", function(event) {
+      event.preventDefault();
+      var tid = $("#form-taxon-id").val();
+      let target_div = $(`.item[data-taxon_id=${tid}]`);
+      var form_data = new FormData();
+      var image_file = $(this).find('input[name="taxon[image]"]')[0].files[0];
+      var name = $(this)
+        .find('input[name="taxon[name]"]')
+        .val();
+      var themes = $("#taxons_taxons").val();
+      var csrf = $(this)
+        .find("input:hidden")
+        .val();
+      form_data.append("image", image_file);
+      form_data.append("name", name);
+      form_data.append("themes", themes);
+      form_data.append("_csrf_token", csrf);
+      form_data.append("id", tid);
+      $.ajax({
+        url: "/taxonomy",
+        type: "POST",
+        data: form_data,
+        processData: false,
+        contentType: false,
+        success: function(result) {
+          $("#taxon-modal").modal("hide");
+          $(result.html)
             .hide()
             .appendTo(children_ul)
-            .show('normal')
-          }
-        });
+            .show("normal");
+        }
       });
+    });
 
-      $("#taxon-edit-body").on("submit", ".edittaxonform", function(event){
-        event.preventDefault();
+    $("#taxon-edit-body").on("submit", ".edittaxonform", function(event) {
+      event.preventDefault();
 
-        var form_data = new FormData();
-        var name = $(this).find("#editform-taxon-name").val();
-        var themes = $("#taxon-edit-body #taxons_taxons").val();
-        var image_file =  $(this).find('input[name="taxon[image]"]')[0].files[0];
-        var id = $(this).find("#editform-taxon-id").val();
+      var form_data = new FormData();
+      var name = $(this)
+        .find("#editform-taxon-name")
+        .val();
+      var themes = $("#taxon-edit-body #taxons_taxons").val();
+      var image_file = $(this).find('input[name="taxon[image]"]')[0].files[0];
+      var id = $(this)
+        .find("#editform-taxon-id")
+        .val();
 
-        form_data.append('taxon[taxon_id]', id);
-        form_data.append('taxon[taxon]', name);
-        form_data.append('taxon[image]', image_file);
-        form_data.append('taxon[themes]', themes);
+      form_data.append("taxon[taxon_id]", id);
+      form_data.append("taxon[taxon]", name);
+      form_data.append("taxon[image]", image_file);
+      form_data.append("taxon[themes]", themes);
 
-        $.ajax({
-          url: '/api/taxonomy/update',
-          type: 'PUT',
-          data: form_data,
-          processData: false,
-          contentType: false,
-          success: function(result) {
-            $("#edittaxon-modal").modal('hide')
-            let taxon_id = result.id;
-            let i_selector = "li[data-taxon_id='" + taxon_id + "'] > span > i"
-            $(i_selector).html(result.name)
-            let span_selector = "li[data-taxon_id='" + taxon_id +"'] > span"
-            let span = $(span_selector);
-            span.css({backgroundColor: '#00FA9A'});
-            span.animate({backgroundColor: '#fbfbfb'}, 'slow', function() {
-              span.removeAttr("style")
-            });
-          },
-          error: function(xhr) {
-            console.log("Update failed")
-            $("#edittaxon-modal").modal('hide')
-          }
-        });
+      $.ajax({
+        url: "/api/taxonomy/update",
+        type: "PUT",
+        data: form_data,
+        processData: false,
+        contentType: false,
+        success: function(result) {
+          $("#edittaxon-modal").modal("hide");
+          let taxon_id = result.id;
+          let i_selector = "li[data-taxon_id='" + taxon_id + "'] > span > i";
+          $(i_selector).html(result.name);
+          let span_selector = "li[data-taxon_id='" + taxon_id + "'] > span";
+          let span = $(span_selector);
+          span.css({ backgroundColor: "#00FA9A" });
+          span.animate({ backgroundColor: "#fbfbfb" }, "slow", function() {
+            span.removeAttr("style");
+          });
+        },
+        error: function(xhr) {
+          console.log("Update failed");
+          $("#edittaxon-modal").modal("hide");
+        }
       });
+    });
 
-      $('.tree li:has(ul)').addClass('parent_li');
-      $('.taxonomy').on('click', "span", function (e) {
-          var children = $(this).parent('li.parent_li').find(' > ul > li');
-          if (children.is(":visible")) {
-              children.hide('fast');
-              $(this).find(' > i').addClass('icon-plus-sign').removeClass('icon-minus-sign');
-          } else {
-              children.show('fast');
-              $(this).find(' > i').addClass('icon-minus-sign').removeClass('icon-plus-sign');
-          }
-          e.stopPropagation();
-      });
+    $(".tree li:has(ul)").addClass("parent_li");
+    $(".taxonomy").on("click", "span", function(e) {
+      var children = $(this)
+        .parent("li.parent_li")
+        .find(" > ul > li");
+      if (children.is(":visible")) {
+        children.hide("fast");
+        $(this)
+          .find(" > i")
+          .addClass("icon-plus-sign")
+          .removeClass("icon-minus-sign");
+      } else {
+        children.show("fast");
+        $(this)
+          .find(" > i")
+          .addClass("icon-minus-sign")
+          .removeClass("icon-plus-sign");
+      }
+      e.stopPropagation();
+    });
 
-      // handle taxon_id from query from URl
-      let params = this.get_query_params()
-      if(params["taxon_id"] != undefined)
-      {
-        var id = params["taxon_id"];
-        $(`#taxon-edit-loader`).addClass(`loader`).show();
-        fetch('/api/taxon/' + id)
+    // handle taxon_id from query from URl
+    let params = this.get_query_params();
+    if (params["taxon_id"] != undefined) {
+      var id = params["taxon_id"];
+      $(`#taxon-edit-loader`)
+        .addClass(`loader`)
+        .show();
+      fetch("/api/taxon/" + id)
         .then(function(response) {
-
-          if(!response.ok){
-            $("#edittaxon-modal").modal('hide')
+          if (!response.ok) {
+            $("#edittaxon-modal").modal("hide");
             throw Error("Api failed");
           }
 
-          return response.json()
+          return response.json();
         })
         .then(function(json) {
-          $("#edittaxon-modal").modal({show: true})
+          $("#edittaxon-modal").modal({ show: true });
           $(`#taxon-edit-body`)
-          .empty()
-          .append(json.html)
-          $(`#taxon-edit-loader`).removeClass(`loader`).hide();
-          select2Selector()
+            .empty()
+            .append(json.html);
+          $(`#taxon-edit-loader`)
+            .removeClass(`loader`)
+            .hide();
+          select2Selector();
         })
         .catch(function(error) {
           console.log("Taxon not found");
-        })
-      }
-
-      // Specific logic here
-      console.log('TaxonomyTaxonomyView mounted');
+        });
     }
 
-    get_query_params() {
-      let pairs = window.location.search.slice(1).split('&');
+    // Specific logic here
+    console.log("TaxonomyTaxonomyView mounted");
+  }
 
-      var result = {};
-      pairs.forEach(function(pair){
-        pair = pair.split('=');
-        result[pair[0]] = decodeURIComponent(pair[1] || "");
-      })
-      return result;
-    }
+  get_query_params() {
+    let pairs = window.location.search.slice(1).split("&");
 
-    unmount() {
-      super.unmount();
+    var result = {};
+    pairs.forEach(function(pair) {
+      pair = pair.split("=");
+      result[pair[0]] = decodeURIComponent(pair[1] || "");
+    });
+    return result;
+  }
 
-      // Specific logic here
-      console.log('TaxonomyTaxonomyView unmounted');
-    }
+  unmount() {
+    super.unmount();
+
+    // Specific logic here
+    console.log("TaxonomyTaxonomyView unmounted");
+  }
 }

--- a/apps/admin_app/assets/js/views/taxonomy/taxonomy.js
+++ b/apps/admin_app/assets/js/views/taxonomy/taxonomy.js
@@ -70,7 +70,7 @@ export default class View extends MainView {
 
       $("#taxon-edit-body").on("submit", ".edittaxonform", function(event){
         event.preventDefault();
-        
+
         var form_data = new FormData();
         var name = $(this).find("#editform-taxon-name").val();
         var themes = $("#taxon-edit-body #taxons_taxons").val();
@@ -124,19 +124,28 @@ export default class View extends MainView {
       let params = this.get_query_params()
       if(params["taxon_id"] != undefined)
       {
-        $("#edittaxon-modal").modal({show: true})
         var id = params["taxon_id"];
         $(`#taxon-edit-loader`).addClass(`loader`).show();
         fetch('/api/taxon/' + id)
         .then(function(response) {
+
+          if(!response.ok){
+            $("#edittaxon-modal").modal('hide')
+            throw Error("Api failed");
+          }
+
           return response.json()
         })
         .then(function(json) {
+          $("#edittaxon-modal").modal({show: true})
           $(`#taxon-edit-body`)
           .empty()
           .append(json.html)
           $(`#taxon-edit-loader`).removeClass(`loader`).hide();
           select2Selector()
+        })
+        .catch(function(error) {
+          console.log("Taxon not found");
         })
       }
 

--- a/apps/admin_app/assets/js/views/taxonomy/taxonomy.js
+++ b/apps/admin_app/assets/js/views/taxonomy/taxonomy.js
@@ -4,6 +4,7 @@ import select2Selector from './../../form-helpers/select2-selector';
 export default class View extends MainView {
     mount() {
       super.mount();
+
       let children_ul = null
 
       $(".taxonomy").on("click", ".edit-taxon", function(e){
@@ -69,6 +70,7 @@ export default class View extends MainView {
 
       $("#taxon-edit-body").on("submit", ".edittaxonform", function(event){
         event.preventDefault();
+        
         var form_data = new FormData();
         var name = $(this).find("#editform-taxon-name").val();
         var themes = $("#taxon-edit-body #taxons_taxons").val();
@@ -118,8 +120,39 @@ export default class View extends MainView {
           e.stopPropagation();
       });
 
+      // handle taxon_id from query from URl
+      let params = this.get_query_params()
+      if(params["taxon_id"] != undefined)
+      {
+        $("#edittaxon-modal").modal({show: true})
+        var id = params["taxon_id"];
+        $(`#taxon-edit-loader`).addClass(`loader`).show();
+        fetch('/api/taxon/' + id)
+        .then(function(response) {
+          return response.json()
+        })
+        .then(function(json) {
+          $(`#taxon-edit-body`)
+          .empty()
+          .append(json.html)
+          $(`#taxon-edit-loader`).removeClass(`loader`).hide();
+          select2Selector()
+        })
+      }
+
       // Specific logic here
       console.log('TaxonomyTaxonomyView mounted');
+    }
+
+    get_query_params() {
+      let pairs = window.location.search.slice(1).split('&');
+
+      var result = {};
+      pairs.forEach(function(pair){
+        pair = pair.split('=');
+        result[pair[0]] = decodeURIComponent(pair[1] || "");
+      })
+      return result;
     }
 
     unmount() {

--- a/apps/admin_app/lib/admin_app_web/controllers/template_api/taxonomy_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/template_api/taxonomy_controller.ex
@@ -26,12 +26,19 @@ defmodule AdminAppWeb.TemplateApi.TaxonomyController do
   end
 
   def taxon_edit(conn, %{"taxon_id" => taxon_id}) do
-    taxon = Repo.get(Taxon, taxon_id) |> Repo.preload([:variation_themes, :image])
-    html = render_to_string(TaxonomyView, "taxon_edit_form.html", %{conn: conn, taxon: taxon})
+    case Repo.get(Taxon, taxon_id) |> Repo.preload([:variation_themes, :image]) do
+      nil ->
+        conn
+        |> put_status(:not_found)
+        |> json(%{error: %{message: "Taxon not found"}})
 
-    conn
-    |> put_status(200)
-    |> json(%{html: html})
+      taxon ->
+        html = render_to_string(TaxonomyView, "taxon_edit_form.html", %{conn: conn, taxon: taxon})
+
+        conn
+        |> put_status(200)
+        |> json(%{html: html})
+    end
   end
 
   def update_taxon(conn, %{"taxon" => %{"taxon" => taxon_name, "taxon_id" => taxon_id} = params}) do

--- a/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
@@ -9,9 +9,11 @@
       <a class="nav-link active" href="#tab1default" data-toggle="tab">Product Detail</a>
    </li>
    <%= if  @conn.request_path != product_path(@conn, :new) do %>
-   <li class="nav-item">
-     <a class="nav-link" href="#tab2default" data-toggle="tab">Variants</a>
-   </li>
+   <%= if !is_child_product(@parent_product) do %>
+    <li class="nav-item">
+      <a class="nav-link" href="#tab2default" data-toggle="tab">Variants</a>
+    </li>
+   <% end %>
    <%= if can_add_variant(@parent_product) do %>
    <% end %>
    <li class="nav-item">
@@ -167,12 +169,14 @@
       <% end %>
     </div>
    <% else %>
-    <div class="tab-pane fade p-3" id="tab2default" >
-      <div class="alert alert-info">
-        You can add Product Variants by adding Variation Themes to <span class="badge badge-info"> <%= get_product_category(@parent_product.taxon_id) %> </span> category.
-        <br> Click to <%= link("Add variation theme", to: "/taxonomy?taxon_id=#{@parent_product.taxon_id}", class: "btn btn-primary") %>
+    <%= if !is_child_product(@parent_product) do %>
+      <div class="tab-pane fade p-3" id="tab2default" >
+        <div class="alert alert-info">
+          You can add Product Variants by adding Variation Themes to <span class="badge badge-info"> <%= get_product_category(@parent_product.taxon_id) %> </span> category.
+          <br> Click to <%= link("Add variation theme", to: "/taxonomy?taxon_id=#{@parent_product.taxon_id}", class: "btn btn-primary") %>
+        </div>
       </div>
-    </div>
+    <% end %>
    <% end %>
   <% end %>
   <%= if  @conn.request_path != product_path(@conn, :new) do %>

--- a/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
@@ -1,7 +1,7 @@
 <%= if  @conn.request_path == product_path(@conn, :new) do %>
   <div style="margin-bottom:1rem">
     <span>Product Category </span>
-    <span class="badge badge-secondary"><%= get_product_category(@conn) %></span>
+    <span class="badge badge-secondary"><%= get_product_category(@conn.params["taxon"]) %></span>
   </div>
 <% end %>
 <ul class="nav nav-tabs">
@@ -104,7 +104,8 @@
     <% end %>
   </div>
 
-  <%= if  @conn.request_path != product_path(@conn, :new) and can_add_variant(@parent_product) do %>
+  <%= if  @conn.request_path != product_path(@conn, :new) do %>
+   <%= if can_add_variant(@parent_product)  do %>
     <div class="tab-pane fade p-3" id="tab2default" >
       <div style="background: #f8f9fa;">
         <div class="form-group required">
@@ -165,12 +166,14 @@
       </div>
       <% end %>
     </div>
-  <% else %>
+   <% else %>
     <div class="tab-pane fade p-3" id="tab2default" >
       <div class="alert alert-info">
-        You can add product variaton by adding themes. Click here to <%= link("Add variation theme", to: variation_theme_path(@conn, :index)) %>
+        You can add Product Variants by adding Variation Themes to <span class="badge badge-info"> <%= get_product_category(@parent_product.taxon_id) %> </span> category.
+        <br> Click to <%= link("Add variation theme", to: "/taxonomy?taxon_id=#{@parent_product.taxon_id}", class: "btn btn-primary") %>
       </div>
     </div>
+   <% end %>
   <% end %>
   <%= if  @conn.request_path != product_path(@conn, :new) do %>
   <div class="tab-pane fade p-3" id="tab3default">

--- a/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
@@ -9,10 +9,10 @@
       <a class="nav-link active" href="#tab1default" data-toggle="tab">Product Detail</a>
    </li>
    <%= if  @conn.request_path != product_path(@conn, :new) do %>
+   <li class="nav-item">
+     <a class="nav-link" href="#tab2default" data-toggle="tab">Variants</a>
+   </li>
    <%= if can_add_variant(@parent_product) do %>
-    <li class="nav-item">
-        <a class="nav-link" href="#tab2default" data-toggle="tab">Variants</a>
-    </li>
    <% end %>
    <li class="nav-item">
       <a class="nav-link" href="#tab3default" data-toggle="tab">Images</a>
@@ -103,68 +103,74 @@
     </div>
     <% end %>
   </div>
+
   <%= if  @conn.request_path != product_path(@conn, :new) and can_add_variant(@parent_product) do %>
-  <div class="tab-pane fade p-3
-  " id="tab2default" >
-    <div style="background: #f8f9fa;">
-      <div class="form-group required">
-        <label>Variation Theme</label>
-        <%= select :theme, :theme_id, themes_options(@parent_product), selected: @parent_product.theme_id ,prompt: "", class: "form-control", id: "product_theme_id" %>
-      </div>
-      <div id="variation_options" style="padding: 10px 0px 10px 0px;"></div>
-      <div class="modal fade" id="theme_change_modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-centered" role="document">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h5 class="modal-title" id="exampleModalLongTitle">Warning</h5>
-              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-              <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
-            <div class="modal-body">
-              <div class="alert alert-danger" role="alert">
-                Changing theme will remove all the associated variants.
-                Are you sure you want to do this?
+    <div class="tab-pane fade p-3" id="tab2default" >
+      <div style="background: #f8f9fa;">
+        <div class="form-group required">
+          <label>Variation Theme</label>
+          <%= select :theme, :theme_id, themes_options(@parent_product), selected: @parent_product.theme_id ,prompt: "", class: "form-control", id: "product_theme_id" %>
+        </div>
+        <div id="variation_options" style="padding: 10px 0px 10px 0px;"></div>
+        <div class="modal fade" id="theme_change_modal" tabindex="-1" role="dialog" aria-labelledby="exampleModalCenterTitle" aria-hidden="true">
+          <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content">
+              <div class="modal-header">
+                <h5 class="modal-title" id="exampleModalLongTitle">Warning</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+                </button>
               </div>
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" data-dismiss="modal">No</button>
-              <button id="theme_change_confirm" type="button" class="btn btn-primary">Yes</button>
+              <div class="modal-body">
+                <div class="alert alert-danger" role="alert">
+                  Changing theme will remove all the associated variants.
+                  Are you sure you want to do this?
+                </div>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-dismiss="modal">No</button>
+                <button id="theme_change_confirm" type="button" class="btn btn-primary">Yes</button>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <%= if has_variants(@parent_product) do %>
-    <div>
-      <h3>Product Variants</h3>
-      <table class="table">
-        <thead>
-          <tr>
-            <th>Product ID</th>
-            <%= for option_type <- get_option_types(@parent_product) do %>
-            <th><%= option_type.display_name %></th>
+      <%= if has_variants(@parent_product) do %>
+      <div>
+        <h3>Product Variants</h3>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Product ID</th>
+              <%= for option_type <- get_option_types(@parent_product) do %>
+              <th><%= option_type.display_name %></th>
+              <% end %>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            <%= for variant <- @parent_product.variants do %>
+            <tr>
+              <td><%= variant.id %></td>
+              <%= for option <- variant.options do %>
+              <td class="option-value" contenteditable="true" data-option_value_id="<%= option.id %>"><%= option.value %></td>
+              <% end %>
+              <td>
+                <%= link("Edit", to: product_path(@conn, :edit, variant.id), class: "btn btn-primary") %>
+              </td>
+            </tr>
             <% end %>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          <%= for variant <- @parent_product.variants do %>
-          <tr>
-            <td><%= variant.id %></td>
-            <%= for option <- variant.options do %>
-            <td class="option-value" contenteditable="true" data-option_value_id="<%= option.id %>"><%= option.value %></td>
-            <% end %>
-            <td>
-              <%= link("Edit", to: product_path(@conn, :edit, variant.id), class: "btn btn-primary") %>
-            </td>
-          </tr>
-          <% end %>
-        </tbody>
-      </table>
+          </tbody>
+        </table>
+      </div>
+      <% end %>
     </div>
-    <% end %>
-  </div>
+  <% else %>
+    <div class="tab-pane fade p-3" id="tab2default" >
+      <div class="alert alert-info">
+        You can add product variaton by adding themes. Click here to <%= link("Add variation theme", to: variation_theme_path(@conn, :index)) %>
+      </div>
+    </div>
   <% end %>
   <%= if  @conn.request_path != product_path(@conn, :new) do %>
   <div class="tab-pane fade p-3" id="tab3default">

--- a/apps/admin_app/lib/admin_app_web/views/product_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/product_view.ex
@@ -213,9 +213,9 @@ defmodule AdminAppWeb.ProductView do
     Property.get_formatted_list()
   end
 
-  def get_product_category(conn) do
-    taxon_id = conn.params["taxon"]
+  def get_product_category(nil), do: "NA"
 
+  def get_product_category(taxon_id) do
     with %Taxon{} = taxon <- Repo.get(Taxon, taxon_id),
          {:ok, ancestors} <- Taxonomy.get_ancestors(taxon_id) do
       (ancestors ++ [taxon])


### PR DESCRIPTION
Variation tab should be displayed always for product.

Fixes: [Pivotal story - 162030594](https://www.pivotaltracker.com/story/show/162030594)

## Motivation and Context
By showing `Variation` tab always, we can guide user how to add variant even if there are not themes associated with the selected product category.

## Describe your changes
`admin_app`
-----------------
- Handled taxonomy failure for edit taxon
- Fixed variation tab behave as follows:
  - Variation tab is `visible` if
    - Product is parent product
    - Product is simple product
  - Variation tab is `hidden` if
    - Product is child product ie. variant product
  - We can directly edit product category from variation tab if variants need to be created and category does not have variation theme.

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
