### PR TITLE
Fixes api sending draft products.

### DIFF
--- a/apps/snitch_api/lib/snitch_api/products_context/products_context.ex
+++ b/apps/snitch_api/lib/snitch_api/products_context/products_context.ex
@@ -163,7 +163,7 @@ defmodule SnitchApi.ProductsContext do
     |> like_query(params["filter"], @partial_search_allowables)
   end
 
-  defp filter_query(query, nil, _allowables), do: query
+  defp filter_query(query, nil, _allowables), do: from(q in query, where: ^@default_filter)
 
   defp filter_query(query, filter_params, allowables) do
     filter_params = @default_filter ++ make_filter_params_list(filter_params, allowables)


### PR DESCRIPTION
Adds default filter to product api.

<!--- Provide a general summary of your changes in the Title above -->
<!--- in NOT MORE THAN 50 characters. Keep it short, pls. -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->
- Products api response with no filter params should send only active
  products.

## Describe your changes
<!--- List and detail all changes made in this PR. -->
- Adds default filter to the query when filter params are empty.

## Any further comments?

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
