### PR TITLE
Add triplex migration task in release tasks

### DIFF
--- a/apps/snitch_core/priv/tasks/release_tasks.ex
+++ b/apps/snitch_core/priv/tasks/release_tasks.ex
@@ -50,6 +50,7 @@ defmodule Snitch.Tasks.ReleaseTasks do
     IO.puts("Running migrations for #{app}")
     migrations_path = priv_path_for(repo, "migrations")
     Ecto.Migrator.run(repo, migrations_path, :up, all: true)
+    Mix.Tasks.Triplex.Migrate.run([])
   end
 
   defp run_seeds do


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- in NOT MORE THAN 50 characters. Keep it short, pls. -->

## Motivation and Context
Release tasks in snitch_core took care of any pending migrations in the database but only in the public schema. Running migrations on each existing tenant require an additional call to Triplex.

## Describe your changes
Added Triplex task for handling tenant migrations in release tasks.

## Any further comments?

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
