### PR TITLE
Fix long URL issue after product is edited with long description

### DIFF
--- a/apps/admin_app/lib/admin_app_web/controllers/product_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/product_controller.ex
@@ -75,7 +75,7 @@ defmodule AdminAppWeb.ProductController do
   def update(conn, %{"product" => params}) do
     with %ProductSchema{} = product <- ProductModel.get(params["id"]),
          {:ok, _product} <- ProductModel.update(product, params) do
-      redirect_with_updated_conn(conn, params)
+      redirect_with_updated_conn(conn, @rummage_default)
     end
   end
 


### PR DESCRIPTION
This change will solve the issue of server returning 414 status code when very large description is added in the product edit page.

[Fixes Pivotal - 162307066](https://www.pivotaltracker.com/story/show/162307066)

## Motivation and Context
When we try to edit a product with long text description and then save the product.
The data for product gets saved but the product fields are present in URI after saving the data. As the description is too long the URL also becomes long and we get 414 status code on the page after redirect.

## Describe your changes
Sending default rummage instead of data from the product description form field in update product action.

------

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

<!--- DO NOT REMOVE SECTION BELOW -->
------
Dear Gatekeeper,

Please make sure that the commits that will be merged or rebased into the base
branch are [formatted according to our standards][commit-style].

> The only additional requirement is that the the PR number must appear in the
> commit title in brackets: `(#XXX)`

[commit-style]: https://github.com/aviabird/snitch/blob/develop/CONTRIBUTING.md#styling
