### PR TITLE
Fix image display

### DIFF
--- a/apps/snitch_api/lib/snitch_api_web/views/product_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/product_view.ex
@@ -74,9 +74,16 @@ defmodule SnitchApiWeb.ProductView do
 
   defp get_parent_images(product) do
     variant = Repo.get_by(Variation, child_product_id: product.id)
-    parent_id = variant.parent_product_id
-    parent_product = Repo.get_by(ProductSchema, id: parent_id) |> Repo.preload([:images])
-    parent_product.images
+
+    case variant do
+      nil ->
+        []
+
+      _ ->
+        parent_id = variant.parent_product_id
+        parent_product = Repo.get_by(ProductSchema, id: parent_id) |> Repo.preload([:images])
+        parent_product.images
+    end
   end
 
   def rating_summary(product, _conn) do

--- a/apps/snitch_api/lib/snitch_api_web/views/product_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/product_view.ex
@@ -1,6 +1,8 @@
 defmodule SnitchApiWeb.ProductView do
   use SnitchApiWeb, :view
   use JaSerializer.PhoenixView
+  alias Snitch.Data.Schema.Variation
+  alias Snitch.Data.Schema.Product, as: ProductSchema
   alias Snitch.Data.Model.{Product, ProductReview}
   alias Snitch.Core.Tools.MultiTenancy.Repo
 
@@ -22,7 +24,8 @@ defmodule SnitchApiWeb.ProductView do
     :images,
     :rating_summary,
     :is_orderable,
-    :display_price
+    :display_selling_price,
+    :display_max_retail_price
   ])
 
   def selling_price(product) do
@@ -33,15 +36,47 @@ defmodule SnitchApiWeb.ProductView do
     Money.round(product.max_retail_price, currency_digits: :cash)
   end
 
-  def display_price(product) do
+  def display_max_retail_price(product) do
+    product.max_retail_price |> to_string
+  end
+
+  def display_selling_price(product) do
     product.selling_price |> to_string
   end
 
   def images(product, _conn) do
-    product = product |> Repo.preload(:images)
+    product = product |> Repo.preload([:images, products: :products])
 
-    product.images
-    |> Enum.map(fn image -> %{"product_url" => Product.image_url(image.name, product)} end)
+    product_images =
+      case product.products do
+        [] ->
+          images = product.images
+
+          if images != [] do
+            images
+          else
+            get_parent_images(product)
+          end
+
+        products ->
+          product.images
+      end
+
+    case product_images do
+      [] ->
+        [%{"product_url" => nil}]
+
+      images ->
+        images
+        |> Enum.map(fn image -> %{"product_url" => Product.image_url(image.name, product)} end)
+    end
+  end
+
+  defp get_parent_images(product) do
+    variant = Repo.get_by(Variation, child_product_id: product.id)
+    parent_id = variant.parent_product_id
+    parent_product = Repo.get_by(ProductSchema, id: parent_id) |> Repo.preload([:images])
+    parent_product.images
   end
 
   def rating_summary(product, _conn) do


### PR DESCRIPTION
Return parent product images if the variant has no images.

## Why?
If a variant has no images, we need to display its parent product's image. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
<!--- List and detail all changes made in this PR. -->
Checking the images for a variant. If it's there, return the same or else return the parent product's images. 


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

