### PR TITLE
Default zone corresponding to stocklocation

### DIFF
--- a/apps/admin_app/lib/admin_app_web/controllers/stock_location_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/stock_location_controller.ex
@@ -3,6 +3,7 @@ defmodule AdminAppWeb.StockLocationController do
   alias Snitch.Domain.StockLocation, as: SLDomain
   alias Snitch.Data.Model.StockLocation, as: SLModel
   alias Snitch.Data.Schema.StockLocation, as: SLSchema
+  alias Snitch.Data.Model.CountryZone, as: CZone
 
   def index(conn, _params) do
     data = %{stock_locations: SLDomain.search()}
@@ -28,7 +29,8 @@ defmodule AdminAppWeb.StockLocationController do
   end
 
   def create(conn, %{"stock_location" => stock_location}) do
-    with {:ok, _} <- SLModel.create(stock_location) do
+    with {:ok, location} <- SLModel.create(stock_location) do
+      create_zone_for_location(location)
       conn
       |> put_flash(:info, "Stock Location created successfully")
       |> redirect(to: stock_location_path(conn, :index))
@@ -38,6 +40,12 @@ defmodule AdminAppWeb.StockLocationController do
         |> put_flash(:error, "Error: Some validations failed")
         |> render("new.html", changeset: %{changeset | action: :insert})
     end
+  end
+
+  defp create_zone_for_location(location) do
+    country_ids = [location.country_id]
+    name = location.name <> "_zone"
+    CZone.create(name, nil, country_ids)
   end
 
   def edit(conn, %{"id" => id}) do

--- a/apps/admin_app/lib/admin_app_web/controllers/stock_location_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/stock_location_controller.ex
@@ -3,7 +3,9 @@ defmodule AdminAppWeb.StockLocationController do
   alias Snitch.Domain.StockLocation, as: SLDomain
   alias Snitch.Data.Model.StockLocation, as: SLModel
   alias Snitch.Data.Schema.StockLocation, as: SLSchema
+  alias Snitch.Data.Schema.Zone
   alias Snitch.Data.Model.CountryZone, as: CZone
+  alias Snitch.Core.Tools.MultiTenancy.Repo
 
   def index(conn, _params) do
     data = %{stock_locations: SLDomain.search()}
@@ -31,6 +33,7 @@ defmodule AdminAppWeb.StockLocationController do
   def create(conn, %{"stock_location" => stock_location}) do
     with {:ok, location} <- SLModel.create(stock_location) do
       create_zone_for_location(location)
+
       conn
       |> put_flash(:info, "Stock Location created successfully")
       |> redirect(to: stock_location_path(conn, :index))
@@ -45,7 +48,18 @@ defmodule AdminAppWeb.StockLocationController do
   defp create_zone_for_location(location) do
     country_ids = [location.country_id]
     name = location.name <> "_zone"
-    CZone.create(name, nil, country_ids)
+    zones = Repo.all(Zone)
+
+    check_zone_with_country =
+      Enum.find(zones, fn zone -> Enum.member?(CZone.member_ids(zone), location.country_id) end)
+
+    case check_zone_with_country do
+      nil ->
+        CZone.create(name, nil, country_ids)
+
+      zone ->
+        nil
+    end
   end
 
   def edit(conn, %{"id" => id}) do

--- a/apps/admin_app/lib/admin_app_web/templates/stock_location/_form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/stock_location/_form.html.eex
@@ -3,9 +3,6 @@
   <%= input f, :name, nil, description: "Name to identify your stock location.", is_horizontal: true %>
 </div>
 <div class="form-group row ">
-  <%= input f, :admin_name, nil, description: "Name to identify stock location within your system.", is_horizontal: true %>
-</div>
-<div class="form-group row ">
   <%= textarea_input f, :address_line_1, nil, description: "Eg. 319, Amanora chambers", is_horizontal: true %>
 </div>
 <div class="form-group row ">

--- a/apps/admin_app/lib/admin_app_web/templates/stock_location/show.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/stock_location/show.html.eex
@@ -5,7 +5,6 @@
   <hr/>
   <ul class="col">
     <li><strong class="text-danger">Name:</strong> <%= @stock_location.name %></li>
-    <li><strong class="text-danger">Admin Name:</strong> <%= @stock_location.admin_name %></li>
     <li>
       <strong class="text-danger">Address:</strong>
       <ul>

--- a/apps/snitch_api/lib/snitch_api_web/views/stock_location_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/stock_location_view.ex
@@ -4,7 +4,6 @@ defmodule SnitchApiWeb.StockLocationView do
 
   attributes([
     :name,
-    :admin_name,
     :default,
     :address_line_1,
     :address_line_2,

--- a/apps/snitch_core/lib/core/data/schema/stock/stock_location.ex
+++ b/apps/snitch_core/lib/core/data/schema/stock/stock_location.ex
@@ -20,8 +20,6 @@ defmodule Snitch.Data.Schema.StockLocation do
 
   schema "snitch_stock_locations" do
     field(:name, :string)
-    # Internal system name
-    field(:admin_name, :string)
     field(:default, :boolean, default: false)
 
     field(:address_line_1, :string)
@@ -45,7 +43,7 @@ defmodule Snitch.Data.Schema.StockLocation do
   end
 
   @required_fields ~w(name address_line_1 state_id country_id)a
-  @cast_fields ~w(admin_name address_line_2 city zip_code phone propagate_all_variants)a ++
+  @cast_fields ~w(address_line_2 city zip_code phone propagate_all_variants)a ++
                  ~w(backorderable_default active)a ++ @required_fields
 
   @spec create_changeset(t, map) :: Ecto.Changeset.t()
@@ -64,5 +62,6 @@ defmodule Snitch.Data.Schema.StockLocation do
     |> validate_format(:phone, ~r/^\d{10}$/)
     |> foreign_key_constraint(:state_id)
     |> foreign_key_constraint(:country_id)
+    |> unique_constraint(:name)
   end
 end

--- a/apps/snitch_core/lib/core/data/schema/zone/zone.ex
+++ b/apps/snitch_core/lib/core/data/schema/zone/zone.ex
@@ -32,9 +32,9 @@ defmodule Snitch.Data.Schema.Zone do
     timestamps()
   end
 
-  @update_fields ~w(name description)a
-  @create_fields [:zone_type | @update_fields]
-
+  @required_fields ~w(name zone_type)a
+  @optional_fields ~w(description)a
+  @create_fields @required_fields ++ @optional_fields
   @doc """
   Returns a `Zone` changeset to create a new `zone`.
   """
@@ -42,7 +42,7 @@ defmodule Snitch.Data.Schema.Zone do
   def create_changeset(zone, params) do
     zone
     |> cast(params, @create_fields)
-    |> validate_required(@create_fields)
+    |> validate_required(@required_fields)
     |> validate_inclusion(:zone_type, @valid_zone_types)
   end
 
@@ -52,7 +52,7 @@ defmodule Snitch.Data.Schema.Zone do
   @spec update_changeset(t, map) :: Ecto.Changeset.t()
   def update_changeset(zone, params) do
     zone
-    |> cast(params, @update_fields)
-    |> validate_required(@create_fields)
+    |> cast(params, @create_fields)
+    |> validate_required(@required_fields)
   end
 end

--- a/apps/snitch_core/lib/core/tools/helpers/stock.ex
+++ b/apps/snitch_core/lib/core/tools/helpers/stock.ex
@@ -15,7 +15,7 @@ defmodule Snitch.Tools.Helper.Stock do
       %{count_on_hand: 0},
       %{count_on_hand: 6}
     ],
-    "origin" => [ # this is the `admin_name` of the `stock_location`
+    "origin" => [ # this is the `name` of the `stock_location`
       %{count_on_hand: 3},
       %{count_on_hand: 3},
       %{count_on_hand: 3}
@@ -36,7 +36,6 @@ defmodule Snitch.Tools.Helper.Stock do
 
   @stock_location %{
     name: nil,
-    admin_name: nil,
     address_line_1: "",
     state_id: nil,
     country_id: nil,
@@ -50,7 +49,7 @@ defmodule Snitch.Tools.Helper.Stock do
 
   def stock_locations_with_manifest(manifest) do
     Enum.map(manifest, fn {name, params} ->
-      %{Map.merge(@stock_location, params) | admin_name: name}
+      %{Map.merge(@stock_location, params) | name: name}
     end)
   end
 

--- a/apps/snitch_core/priv/repo/demo/demo_data/stock_locations.csv
+++ b/apps/snitch_core/priv/repo/demo/demo_data/stock_locations.csv
@@ -1,3 +1,3 @@
-name,admin_name,default,address_line_1,address_line_2,city,zip_code,phone,propagate_all_variants,active
-Hall of Fame,root,false,Oxford Hallmark,lane 3,abc,232233,8877996675,true,true
-Wall street,John Doe,false,Westin Park,street 4,Worli,234567,4559667665,true,true
+name,default,address_line_1,address_line_2,city,zip_code,phone,propagate_all_variants,active
+Hall of Fame,false,Oxford Hallmark,lane 3,abc,232233,8877996675,true,true
+Wall street,false,Westin Park,street 4,Worli,234567,4559667665,true,true

--- a/apps/snitch_core/priv/repo/demo/stock_locations.ex
+++ b/apps/snitch_core/priv/repo/demo/stock_locations.ex
@@ -13,13 +13,13 @@ defmodule Snitch.Demo.StockLocation do
         product_path
         |> File.read!
         |> CSV.parse_string
-        |> Enum.each(fn [name, admin_name, default, address_line_1, address_line_2,
+        |> Enum.each(fn [name, default, address_line_1, address_line_2,
         city, zip_code, phone, propagate_all_variants, active] ->
 
             default = String.to_existing_atom(default)
             active = String.to_existing_atom(active)
             propagate_all_variants = String.to_existing_atom(propagate_all_variants)
-            create_stock_location!(name, admin_name, default, address_line_1, address_line_2, city, zip_code, phone, propagate_all_variants, active, state, state.country)
+            create_stock_location!(name, default, address_line_1, address_line_2, city, zip_code, phone, propagate_all_variants, active, state, state.country)
 
         end)
     end
@@ -31,10 +31,9 @@ defmodule Snitch.Demo.StockLocation do
         |> Enum.random()
     end
 
-    def create_stock_location!(name, admin_name, default, address_line_1, address_line_2, city, zip_code, phone, propagate_all_variants, active, state, country) do
+    def create_stock_location!(name, default, address_line_1, address_line_2, city, zip_code, phone, propagate_all_variants, active, state, country) do
         params = %{
             name: name,
-            admin_name: admin_name,
             default: default,
             address_line_1: address_line_1,
             address_line_2: address_line_2,

--- a/apps/snitch_core/priv/repo/migrations/20181210061831_remove_admin_name.exs
+++ b/apps/snitch_core/priv/repo/migrations/20181210061831_remove_admin_name.exs
@@ -1,0 +1,12 @@
+defmodule Snitch.Repo.Migrations.RemoveAdminName do
+  use Ecto.Migration
+
+  def change do
+    alter table("snitch_stock_locations") do
+      remove :admin_name
+    end
+
+    create unique_index("snitch_stock_locations", [:name])
+  end
+end
+

--- a/apps/snitch_core/priv/repo/seed/stock_location.ex
+++ b/apps/snitch_core/priv/repo/seed/stock_location.ex
@@ -8,7 +8,6 @@ defmodule Snitch.Seed.StockLocation do
 
     create_stock_location!(
       "default",
-      "default",
       true,
       "Oxford Hallmark",
       "Street 1",
@@ -30,7 +29,6 @@ defmodule Snitch.Seed.StockLocation do
 
   def create_stock_location!(
         name,
-        admin_name,
         default,
         address_line_1,
         address_line_2,
@@ -44,7 +42,6 @@ defmodule Snitch.Seed.StockLocation do
       ) do
     params = %{
       name: name,
-      admin_name: admin_name,
       default: default,
       address_line_1: address_line_1,
       address_line_2: address_line_2,

--- a/apps/snitch_core/priv/repo/seed/stocks.ex
+++ b/apps/snitch_core/priv/repo/seed/stocks.ex
@@ -23,8 +23,8 @@ defmodule Snitch.Seed.Stocks do
 
     Repo.transaction(fn ->
       locations =
-        Enum.reduce(seed_stock_locations!(), %{}, fn %{id: id, admin_name: nickname}, acc ->
-          Map.put(acc, nickname, id)
+        Enum.reduce(seed_stock_locations!(), %{}, fn %{id: id, name: name}, acc ->
+          Map.put(acc, name, id)
         end)
 
       seed_stock_items!(variants, locations)
@@ -36,7 +36,6 @@ defmodule Snitch.Seed.Stocks do
       [
         %{
           name: "Statue of Liberty",
-          admin_name: "default",
           default: true,
           address_line_1: "Liberty Island",
           address_line_2: "Manhattan",
@@ -50,7 +49,6 @@ defmodule Snitch.Seed.Stocks do
         },
         %{
           name: "Taj Mahal",
-          admin_name: "warehouse",
           address_line_1: "Dharmapuri, Forest Colony",
           address_line_2: "Tajganj",
           city: "Agra",
@@ -63,7 +61,6 @@ defmodule Snitch.Seed.Stocks do
         },
         %{
           name: "Colosseum",
-          admin_name: "backup",
           address_line_1: "Piazza del Colosseo, 1",
           address_line_2: "",
           city: "",
@@ -76,7 +73,6 @@ defmodule Snitch.Seed.Stocks do
         },
         %{
           name: "Sinhagadh Fort",
-          admin_name: "origin",
           address_line_1: "Sinhagad Ghat Road",
           address_line_2: "Thoptewadi",
           city: "Pune",

--- a/apps/snitch_core/test/domain/shipment_test.exs
+++ b/apps/snitch_core/test/domain/shipment_test.exs
@@ -512,7 +512,7 @@ defmodule Snitch.Domain.ShipmentTest do
     {_, stock_locations} = Repo.insert_all(StockLocation, locations, returning: true)
 
     Enum.reduce(stock_locations, %{}, fn sl, acc ->
-      Map.put(acc, sl.admin_name, sl)
+      Map.put(acc, sl.name, sl)
     end)
   end
 

--- a/apps/snitch_core/test/domain/splitters/weight_test.exs
+++ b/apps/snitch_core/test/domain/splitters/weight_test.exs
@@ -309,7 +309,7 @@ defmodule Snitch.Domain.Splitter.WeightTest do
     {_, stock_locations} = Repo.insert_all(StockLocation, locations, returning: true)
 
     Enum.reduce(stock_locations, %{}, fn sl, acc ->
-      Map.put(acc, sl.admin_name, sl)
+      Map.put(acc, sl.name, sl)
     end)
   end
 

--- a/apps/snitch_core/test/support/factory/stock.ex
+++ b/apps/snitch_core/test/support/factory/stock.ex
@@ -15,7 +15,6 @@ defmodule Snitch.Factory.Stock do
 
         %StockLocation{
           name: sequence("Colosseum"),
-          admin_name: sequence("origin"),
           default: false,
           address_line_1: "Piazza del Colosseo, 1",
           address_line_2: "",


### PR DESCRIPTION
## Why?
To ensure successful package creation,  we need to create zone corresponding to the stocklocation. 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
Creating zone just after the stocklocation is created if there's no such zone which has given stocklocation's country as member.
<!--- List and detail all changes made in this PR. -->

[delivers #162407265](https://www.pivotaltracker.com/story/show/162407265)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

