### PR TITLE
Fixes product edit page UI.

### DIFF
--- a/apps/admin_app/assets/css/custom/custom.scss
+++ b/apps/admin_app/assets/css/custom/custom.scss
@@ -12,7 +12,7 @@ body {
   .stickformbutton {
     position: fixed;
     bottom: -16px;
-    width: 97%;
+    width: 95%;
     background-color: $white;
     margin-left: -31px;
     padding: 8px 10px 4px;

--- a/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
@@ -103,8 +103,10 @@
       <div class="col-sm-10">
         <%= button("Cancel", to: product_path(@conn, :index), method: "get",  type: "button",
           class: "btn btn-secondary btn-outline-secondary submit-btn float-left") %>
-        <%= submit "Save", class: "btn  btn-primary submit-btn float-right", id: "form-save-btn" %>
-        <%= submit "Save & Publish  ", class: "btn  btn-primary submit-btn float-right", id: "form-save-publish-btn" %>
+          <div class="float-right">
+            <%= submit "Save", class: "btn  btn-primary submit-btn", id: "form-save-btn" %>
+            <%= submit "Save & Publish  ", class: "btn  btn-primary submit-btn", id: "form-save-publish-btn" %>
+          </div>
       </div>
     </div>
     <% end %>


### PR DESCRIPTION

## Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->
- We required product edit page buttons to fit inside the page.
- We need save button to display left to the save and publish button in
  product edit page.

## This change addresses the need by:
<!--- List and detail all changes made in this PR. -->
- Because product edit page was not displaying button inside the page.
- Because save button was coming to the right of save and publish button.

[delivers #162606583]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

