### PR TITLE
Product advanced section

### DIFF
--- a/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
@@ -62,7 +62,7 @@
     <div data-toggle="collapse" data-target="#advanced_section" style="margin-bottom:1rem;padding:0.5rem;border:1px solid #ddd;cursor:pointer" >
       <span>Advanced Section</span>
     </div>
-    <div id="advanced_section" >
+    <div id="advanced_section" class="collapse">
       <div class="form-group row ">
       <label  class="col-sm-3 col-form-label">
         <div class="label">

--- a/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
@@ -58,7 +58,12 @@
         </div>
       </div>
     </div>
-    <div class="form-group row ">
+
+    <div data-toggle="collapse" data-target="#advanced_section" style="margin-bottom:1rem;padding:0.5rem;border:1px solid #ddd;cursor:pointer" >
+      <span>Advanced Section</span>
+    </div>
+    <div id="advanced_section" >
+      <div class="form-group row ">
       <label  class="col-sm-3 col-form-label">
         <div class="label">
           Maximum Retail Price
@@ -72,33 +77,35 @@
         </div>
       </div>
     </div>
-    <div class="form-group row ">
+      <div class="form-group row ">
       <%= select_input f, :shipping_category_id, get_shipping_category(), nil, is_horizontal: true, description: "Select appropriate shipping method for the product eg. Heavy for Washing Machine, Light for T-shirt." %>
     </div>
-    <div class="form-group row ">
+      <div class="form-group row ">
       <%= select_input f, :brand_id, get_brand_options(@brands), nil, is_horizontal: true, description: "Select branch of the product Eg. Levi's.", prompt: "Choose your brand" %>
     </div>
-    <div class="form-group row ">
+      <div class="form-group row ">
       <%= input f, :meta_title_, nil, is_horizontal: true, description: "A short title which helps improve the SEO of the product." %>
     </div>
-    <div class="form-group row ">
+      <div class="form-group row ">
       <%= textarea_input f, :meta_description, nil, is_horizontal: true, description: "Meta description is the short text which helps to improve SEO of the product." %>
     </div>
-    <div class="form-group row ">
+      <div class="form-group row ">
       <%= input f, :meta_keywords, nil, is_horizontal: true, description: "Meta keywords are tags which helps to improve SEO of the product." %>
     </div>
-    <div class="form-group row ">
+      <div class="form-group row ">
       <%= input f, :height, nil, is_horizontal: true, description: "Specifies height of the product." %>
     </div>
-    <div class="form-group row ">
+      <div class="form-group row ">
       <%= input f, :width, nil, is_horizontal: true, description: "Specifies width of the product." %>
     </div>
-    <div class="form-group row ">
+      <div class="form-group row ">
       <%= input f, :depth, nil, is_horizontal: true, description: "Specifies depth of the product." %>
     </div>
-    <div class="form-group row ">
+      <div class="form-group row ">
       <%= input f, :weight, nil, is_horizontal: true, description: "Specifies weight of the product." %>
     </div>
+    </div>
+
     <div class="form-group row stickformbutton">
       <div class="col-sm-10">
         <%= button("Cancel", to: product_path(@conn, :index), method: "get",  type: "button",
@@ -132,7 +139,7 @@
               </div>
               <div class="modal-body">
                 <div class="alert alert-danger" role="alert">
-                  Changing the variation theme would remove all the existing variants, 
+                  Changing the variation theme would remove all the existing variants,
                   are you sure you want to proceed?
                 </div>
               </div>


### PR DESCRIPTION
Why?
While product creation there is lot of information that is not mandatory for the user to fill to create a product. 

## This change addresses the need by:
Now there will be `Advanced Section` which will always be collapsed and on clicking it the other form details will be shown.

[delivers #162156469]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

