### PR TITLE
Fixes filters not preserved for product delete.

### DIFF
--- a/apps/admin_app/lib/admin_app_web/controllers/product_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/product_controller.ex
@@ -230,11 +230,11 @@ defmodule AdminAppWeb.ProductController do
     end)
   end
 
-  def delete(conn, %{"id" => id}) do
+  def delete(conn, %{"id" => id} = params) do
     with {:ok, _product} <- ProductModel.delete(id) do
       conn
       |> put_flash(:info, "Product deleted successfully")
-      |> redirect(to: product_path(conn, :index))
+      |> redirect_with_updated_conn(params)
     end
   end
 


### PR DESCRIPTION

## Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->
- While deleting a product default filters were taken and
  applied filters were not selected after redirection.

## This change addresses the need by:
<!--- List and detail all changes made in this PR. -->
- Updating controller to use method for redirection with
  rummage params.

[finishes #162695042]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

