### PR TITLE
Fixing the image url

### DIFF
--- a/apps/snitch_api/lib/snitch_api_web/views/product_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/product_view.ex
@@ -97,7 +97,7 @@ defmodule SnitchApiWeb.ProductView do
 
     case variant do
       nil ->
-        []
+        %{images: [], parent_product: nil}
 
       _ ->
         parent_id = variant.parent_product_id

--- a/apps/snitch_api/lib/snitch_api_web/views/product_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/product_view.ex
@@ -70,16 +70,19 @@ defmodule SnitchApiWeb.ProductView do
           images = product.images
 
           if images != [] do
-            images
+            get_images(images, product)
           else
-            get_parent_images(product)
+            %{images: images, parent_product: parent_product} = get_parent_images(product)
+            get_images(images, parent_product)
           end
 
         products ->
-          product.images
+          get_images(product.images, product)
       end
+  end
 
-    case product_images do
+  defp get_images(images, product) do
+    case images do
       [] ->
         [%{"product_url" => nil}]
 
@@ -99,7 +102,7 @@ defmodule SnitchApiWeb.ProductView do
       _ ->
         parent_id = variant.parent_product_id
         parent_product = Repo.get_by(ProductSchema, id: parent_id) |> Repo.preload([:images])
-        parent_product.images
+        %{images: parent_product.images, parent_product: parent_product}
     end
   end
 

--- a/apps/snitch_core/lib/core/tools/helpers/image_uploader.ex
+++ b/apps/snitch_core/lib/core/tools/helpers/image_uploader.ex
@@ -17,7 +17,8 @@ defmodule Snitch.Tools.Helper.ImageUploader do
   Validates image file type.
   """
   def validate({file, _}) do
-    ~w(.jpg .jpeg .gif .png) |> Enum.member?(Path.extname(file.file_name))
+    file_extension = file.file_name |> Path.extname() |> String.downcase()
+    ~w(.jpg .jpeg .gif .png) |> Enum.member?(file_extension)
   end
 
   @doc """


### PR DESCRIPTION
## Why?
The image url returned for variants with no image needed to be fixed.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
<!--- List and detail all changes made in this PR. -->
Minor code refactor - passing image name and parent_product's id instead of product's own id if it's a variant with no image in ImageUploader.url function.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

