### PR TITLE
Fixed release task to automatically run migrations for each tenant

### DIFF
--- a/apps/snitch_core/priv/tasks/release_tasks.ex
+++ b/apps/snitch_core/priv/tasks/release_tasks.ex
@@ -16,7 +16,7 @@ defmodule Snitch.Tasks.ReleaseTasks do
     stop_services()
   end
 
-  def seed()do
+  def seed() do
     start_services()
 
     run_migrations()
@@ -50,7 +50,16 @@ defmodule Snitch.Tasks.ReleaseTasks do
     IO.puts("Running migrations for #{app}")
     migrations_path = priv_path_for(repo, "migrations")
     Ecto.Migrator.run(repo, migrations_path, :up, all: true)
-    Mix.Tasks.Triplex.Migrate.run([])
+
+    Enum.each(Triplex.all(repo), fn tenant ->
+      Ecto.Migrator.run(
+        repo,
+        migrations_path,
+        :up,
+        all: true,
+        prefix: tenant
+      )
+    end)
   end
 
   defp run_seeds do


### PR DESCRIPTION
Running migrations on tenants failed in production since Mix is a build tool and [not available in production releases](https://elixirforum.com/t/mix-project-missing-in-elixir-phoenix-prod-release/11413). 
Earlier implementation relied on Mix to run migrations.
The fix runs migrations directly through Ecto's methods.
