### PR TITLE
disable currency change

### DIFF
--- a/apps/admin_app/lib/admin_app_web/templates/general_settings/_form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/general_settings/_form.html.eex
@@ -28,8 +28,9 @@
                   <div class="label-txt">Default currency of the store</div>
               </label>
               <div class="col-sm-9 input-group">
-                <%= select f, :currency, get_currency(), value: f.data.currency, class: "form-control" %>
+                <%= select f, :currency, get_currency(), value: "USD", class: "form-control", disabled: true %>
               </div>
+              <%= hidden_input f, :currency, class: "form-control", value: "USD" %>
             </div>
             <%= if @changeset.data.image != nil do %>
                 <div class="img-wrap col-3 p-1">


### PR DESCRIPTION
## Why?
Since an admin can change the currency from general settings, this results in existing data with a different currency to conflict with the new one.
Hence, as an admin he should not be able to change the currency again from the admin panel.

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
1. Disabling the select currency field in general settings form so that it can't be fiddled with.
2. Adding a hidden field with same name and value as that of the select input field mentioned above
    since disabled fields can't be passed as request params.

<!--- List and detail all changes made in this PR. -->

[delivers #162868006](https://www.pivotaltracker.com/story/show/162868006)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

