### PR TITLE
Dashboard page state count and date.

### DIFF
--- a/apps/admin_app/lib/admin_app_web/controllers/dashboard_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/dashboard_controller.ex
@@ -9,10 +9,16 @@ defmodule AdminAppWeb.DashboardController do
 
     conn
     |> assign(:order_state_counts, get_order_state_count(start_date, end_date))
-    |> assign(:product_state_counts, get_product_state_count(start_date, end_date))
+    |> assign(:product_state_counts, get_product_state_count())
     |> assign(:order_datepoints, get_order_datapoints(start_date, end_date))
     |> assign(:payment_datapoints, get_payment_datapoints(start_date, end_date))
+    |> assign(:start_date, naive_date_to_string(start_date))
+    |> assign(:end_date, naive_date_to_string(end_date))
     |> render("index.html")
+  end
+
+  defp naive_date_to_string(date) do
+    date |> NaiveDateTime.to_date() |> Date.to_string()
   end
 
   defp get_naive_date_time(date, time, default_date \\ Date.utc_today())
@@ -53,8 +59,8 @@ defmodule AdminAppWeb.DashboardController do
     Model.Order.get_order_count_by_state(start_date, end_date)
   end
 
-  defp get_product_state_count(start_date, end_date) do
-    Model.Product.get_product_count_by_state(start_date, end_date)
+  defp get_product_state_count() do
+    Model.Product.get_product_count_by_state()
   end
 
   @spec get_order_datapoints(any(), any()) :: %{data: any(), labels: any()}

--- a/apps/admin_app/lib/admin_app_web/templates/dashboard/index.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/dashboard/index.html.eex
@@ -16,13 +16,11 @@
         <form action="/dashboard" class="form-inline my-2 float-sm-right">
           <div class="form-group p-2">
             <label for="from" class="col-form-label-sm pr-2">From : </label>
-            <input class="form-control form-control-sm" type="date" name="from" value=<%=get_date(@conn.query_params,
-              "from" ) %> onchange="this.form.submit()">
+            <input class="form-control form-control-sm" type="date" name="from" value=<%= @start_date %> onchange="this.form.submit()">
           </div>
           <div class="form-group p-2">
             <label for="to" class="col-form-label-sm pr-2">To : </label>
-            <input class="form-control form-control-sm" type="date" name="to" value=<%=get_date(@conn.query_params,
-              "to" ) %> onchange="this.form.submit()">
+            <input class="form-control form-control-sm" type="date" name="to" value=<%= @end_date %> onchange="this.form.submit()">
           </div>
         </form>
       </div>

--- a/apps/admin_app/lib/admin_app_web/views/dashboard_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/dashboard_view.ex
@@ -2,24 +2,4 @@ defmodule AdminAppWeb.DashboardView do
   use AdminAppWeb, :view
 
   alias AdminAppWeb.Helpers
-
-  def get_date(params, key) do
-    get_time(params, key, params[key])
-  end
-
-  defp get_time(params, "from", nil) do
-    start_time = Ecto.DateTime.utc()
-
-    %{start_time | month: start_time.month - 1}
-    |> Ecto.DateTime.to_date()
-    |> to_string
-  end
-
-  defp get_time(params, "from", param_key) do
-    Helpers.get_date_from_params(params, "from")
-  end
-
-  defp get_time(params, key, param_key) do
-    Helpers.get_date_from_params(params, key)
-  end
 end

--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -349,7 +349,7 @@ defmodule Snitch.Data.Model.Product do
     Enum.reduce(stocks, 0, fn stock, acc -> stock.count_on_hand + acc end)
   end
 
-  def get_product_count_by_state(start_date, end_date) do
+  def get_product_count_by_state() do
     child_product_ids =
       Variation
       |> select([v], v.child_product_id)
@@ -358,8 +358,7 @@ defmodule Snitch.Data.Model.Product do
     Product
     |> where(
       [p],
-      p.inserted_at >= ^start_date and p.inserted_at <= ^end_date and p.state in ^@product_states and
-        p.id not in ^child_product_ids
+      p.state in ^@product_states and p.id not in ^child_product_ids
     )
     |> group_by([p], p.state)
     |> select([p], %{state: p.state, count: count(p.id)})

--- a/apps/snitch_core/lib/core/tools/helpers/image_uploader.ex
+++ b/apps/snitch_core/lib/core/tools/helpers/image_uploader.ex
@@ -24,24 +24,24 @@ defmodule Snitch.Tools.Helper.ImageUploader do
   def transform(:original, _) do
     {:convert,
      fn input, output ->
-      """
-      -filter Triangle
-      -define filter:support=2
-      -thumbnail 600x800
-      -unsharp 0.25x0.25+8+0.065
-      -dither None
-      -posterize 136
-      -quality 82
-      -define jpeg:fancy-upsampling=off
-      -define png:compression-filter=5
-      -define png:compression-level=9
-      -define png:compression-strategy=1
-      -define png:exclude-chunk=all
-      -interlace none
-      -colorspace sRGB
-      -strip #{input}
-      -format jpg jpg:#{output}
-      """
+       """
+       -filter Triangle
+       -define filter:support=2
+       -thumbnail 600x800
+       -unsharp 0.25x0.25+8+0.065
+       -dither None
+       -posterize 136
+       -quality 82
+       -define jpeg:fancy-upsampling=off
+       -define png:compression-filter=5
+       -define png:compression-level=9
+       -define png:compression-strategy=1
+       -define png:exclude-chunk=all
+       -interlace none
+       -colorspace sRGB
+       -strip #{input}
+       -format jpg jpg:#{output}
+       """
      end, :jpg}
   end
 

--- a/apps/snitch_core/test/data/model/product_test.exs
+++ b/apps/snitch_core/test/data/model/product_test.exs
@@ -68,7 +68,7 @@ defmodule Snitch.Data.Model.ProductTest do
       assert is_parent == true
     end
 
-    test "if it is a child",  %{variant: variant} do  
+    test "if it is a child", %{variant: variant} do
       is_child = Product.is_child_product(variant)
       assert is_child == true
     end
@@ -157,9 +157,8 @@ defmodule Snitch.Data.Model.ProductTest do
   end
 
   describe "sellable products list" do
-
     test "if product has no variants" do
-      assert [%ProductSchema{}] = Product.sellable_products_query() |> Repo.all
+      assert [%ProductSchema{}] = Product.sellable_products_query() |> Repo.all()
     end
 
     test "if product has variants" do
@@ -167,11 +166,10 @@ defmodule Snitch.Data.Model.ProductTest do
       product = insert(:product, attrs)
       variant = product.products |> List.first()
       variation = insert(:variation, %{parent_product: product, child_product: variant})
-      sellable_products = Product.sellable_products_query() |> Repo.all |> Enum.map(& &1.id)
+      sellable_products = Product.sellable_products_query() |> Repo.all() |> Enum.map(& &1.id)
       assert Enum.member?(sellable_products, variant.id) == true
       refute Enum.member?(sellable_products, product.id)
     end
-
   end
 
   describe "image handling - " do
@@ -209,9 +207,9 @@ defmodule Snitch.Data.Model.ProductTest do
     end
 
     test "with valid preload params" do
-      preloads = [:products ]
+      preloads = [:products]
       product = Product.get_all_with_preloads(preloads) |> List.first()
-      assert product.products != nil 
+      assert product.products != nil
     end
 
     test "with invalid preload params" do
@@ -285,17 +283,9 @@ defmodule Snitch.Data.Model.ProductTest do
       product = insert(:product)
       {:ok, updated_product} = Product.update(product, %{state: :active, taxon_id: taxon.id})
 
-      next_date =
-        product.inserted_at
-        |> NaiveDateTime.to_date()
-        |> Date.add(1)
-        |> Date.to_string()
-        |> get_naive_date_time()
+      product_state_count = Product.get_product_count_by_state() |> List.first()
 
-      product_state_count =
-        Product.get_product_count_by_state(product.inserted_at, next_date) |> List.first()
-
-      assert product_state_count.count == 1
+      assert product_state_count.count == 2
       assert product_state_count.state == :active
     end
   end


### PR DESCRIPTION

## Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->
- Dashboard page should display all products state count excluding
  date inputs from user.
- Dashboard page with no query params for date should display from
  date in the page.

## This change addresses the need by:
<!--- List and detail all changes made in this PR. -->
- Updating product method to generate state count, for not using
  user inputs for date.
- Updating dashboard controller to send date as params to template.

[delivers #162891353]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

