### PR TITLE
moved aggregations to a separate query

### DIFF
--- a/apps/snitch_api/test/support/settings/products.json
+++ b/apps/snitch_api/test/support/settings/products.json
@@ -58,7 +58,6 @@
           }
         },
         "selling_price": {
-          "type": "nested",
           "properties": {
             "amount": {
               "type": "double"

--- a/apps/snitch_core/lib/core/tools/elasticsearch/product.ex
+++ b/apps/snitch_core/lib/core/tools/elasticsearch/product.ex
@@ -18,8 +18,8 @@ defimpl Elasticsearch.Document, for: Snitch.Data.Schema.Product do
       slug: self_or_parent_product.slug,
       parent_id: self_or_parent_product.id,
       # description: product.description,
-      selling_price: product.selling_price,
-      max_retail_price: product.max_retail_price,
+      selling_price: format_money(product.selling_price),
+      max_retail_price: format_money(product.max_retail_price),
       rating_summary: avg_rating(self_or_parent_product),
       images: product_images(product),
       updated_at: product.updated_at,
@@ -55,7 +55,7 @@ defimpl Elasticsearch.Document, for: Snitch.Data.Schema.Product do
     [
       %{
         id: "Price",
-        value: product.selling_price.amount |> Decimal.to_float()
+        value: Decimal.to_float(product.selling_price.amount)
       },
       %{
         id: "Discount",
@@ -154,6 +154,13 @@ defimpl Elasticsearch.Document, for: Snitch.Data.Schema.Product do
   defp suggest_keywords(%{name: name, meta_keywords: meta_keywords}) do
     keywords = String.split(name, ~r(\s+)) ++ String.split(meta_keywords || "", ~r(\s*\,\s*))
     Enum.filter(keywords, &("" != &1))
+  end
+
+  defp format_money(money) do
+    %{
+      "currency" => money.currency,
+      "amount" => Decimal.to_float(money.amount)
+    }
   end
 
   defp product_discount(product) do

--- a/apps/snitch_core/lib/core/tools/elasticsearch/product_search.ex
+++ b/apps/snitch_core/lib/core/tools/elasticsearch/product_search.ex
@@ -17,7 +17,7 @@ defmodule Snitch.Tools.ElasticSearch.ProductSearch do
       params
       |> convert_to_elastic_query
       |> search_products
-      |> Map.put_new("aggregations", %{})
+      |> Map.put_new("aggregations", generate_aggregations(params))
 
     page = gen_page_links(total, params, conn)
     {collection, page, format_aggregations(aggregations), total}
@@ -35,8 +35,7 @@ defmodule Snitch.Tools.ElasticSearch.ProductSearch do
               generate_query_from_string_facet(params) ++
               generate_query_from_number_facet(params) ++ match_keywords(params)
         }
-      },
-      "aggs" => aggregate_query()
+      }
     }
 
     query
@@ -68,7 +67,7 @@ defmodule Snitch.Tools.ElasticSearch.ProductSearch do
           "path" => "category",
           "query" => %{
             "bool" => %{
-              "must" =>
+              "should" =>
                 Enum.map(values, fn val ->
                   %{
                     "match" => %{
@@ -157,52 +156,70 @@ defmodule Snitch.Tools.ElasticSearch.ProductSearch do
     ]
   end
 
-  defp aggregate_query() do
+  defp generate_aggregations(params) do
     %{
-      "category" => %{
-        "nested" => %{
-          "path" => "category"
-        },
-        "aggs" => %{
-          "aggregations" => %{
-            "terms" => %{
-              "script" => "'Category|' + doc['category.direct_parent'].value"
-            }
+      "aggregations" => aggregations
+    } =
+      search_products(%{
+        "size" => 0,
+        "query" => %{
+          "bool" => %{
+            "must" => tenant_query(),
+            "should" =>
+              match_keywords(params) ++
+                generate_query_from_string_facet(params) ++
+                generate_query_from_number_facet(params)
           }
-        }
-      },
-      "filters" => %{
-        "nested" => %{
-          "path" => "string_facet"
         },
         "aggs" => %{
-          "aggregations" => %{
-            "terms" => %{
-              "script" => "doc['string_facet.id'].value + '|' + doc['string_facet.value'].value"
-            }
-          }
-        }
-      },
-      "range_filters" => %{
-        "nested" => %{
-          "path" => "number_facet"
-        },
-        "aggs" => %{
-          "aggregations" => %{
-            "terms" => %{
-              "field" => "number_facet.id"
+          "category" => %{
+            "nested" => %{
+              "path" => "category"
             },
             "aggs" => %{
-              "facet_value" => %{
-                "stats" => %{
-                  "field" => "number_facet.value"
+              "aggregations" => %{
+                "terms" => %{
+                  "script" => "'Category|' + doc['category.direct_parent'].value"
+                }
+              }
+            }
+          },
+          "filters" => %{
+            "nested" => %{
+              "path" => "string_facet"
+            },
+            "aggs" => %{
+              "aggregations" => %{
+                "terms" => %{
+                  "script" =>
+                    "doc['string_facet.id'].value + '|' + doc['string_facet.value'].value"
+                }
+              }
+            }
+          },
+          "range_filters" => %{
+            "nested" => %{
+              "path" => "number_facet"
+            },
+            "aggs" => %{
+              "aggregations" => %{
+                "terms" => %{
+                  "field" => "number_facet.id"
+                },
+                "aggs" => %{
+                  "facet_value" => %{
+                    "stats" => %{
+                      "field" => "number_facet.value"
+                    }
+                  }
                 }
               }
             }
           }
         }
-      }
-    }
+      })
+
+    aggregations
   end
 
   defp tenant_query() do

--- a/apps/snitch_core/lib/core/tools/elasticsearch/product_search.ex
+++ b/apps/snitch_core/lib/core/tools/elasticsearch/product_search.ex
@@ -164,11 +164,8 @@ defmodule Snitch.Tools.ElasticSearch.ProductSearch do
         "size" => 0,
         "query" => %{
           "bool" => %{
-            "must" => tenant_query(),
-            "should" =>
-              match_keywords(params) ++
-                generate_query_from_string_facet(params) ++
-                generate_query_from_number_facet(params)
+            "must" => tenant_query() ++ match_keywords(params),
+            "should" => generate_query_from_string_facet(params)
           }
         },
         "aggs" => %{

--- a/apps/snitch_core/priv/elasticsearch/products.json
+++ b/apps/snitch_core/priv/elasticsearch/products.json
@@ -58,7 +58,6 @@
           }
         },
         "selling_price": {
-          "type": "nested",
           "properties": {
             "amount": {
               "type": "double"


### PR DESCRIPTION
## Why?
- The selection of one filter was causing the other filters to hide.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
- Separates out the aggregation filter from the query filter.
- Now when one filter is selected the aggregations don't hide. But search works.
- This is still a Patch. Not a complete solution.
<!--- List and detail all changes made in this PR. -->

## Pending.
- filter other than selected filter should update their aggregation counts.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

