### PR TITLE
DB username needs to match with dev.exs

### DIFF
--- a/config/docker/dev/docker-compose-dev.yml
+++ b/config/docker/dev/docker-compose-dev.yml
@@ -19,8 +19,8 @@ services:
     image: postgres:10
     container_name: db
     environment:
-      - POSTGRES_USER=snitch_dev
-      - POSTGRES_PASSWORD=snitch_dev
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
       - POSTGRES_DB=snitch_dev
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2


### PR DESCRIPTION

## Why?
This change is required because docker creates "snitch_dev" user but dev.exs is using "postgres" user to access the db. 
See issue: https://github.com/aviacommerce/avia-docs/pull/29

## This change addresses the need by:
Changing db user from "snitch_dev" to "postgres"

## Checklist
- [x] I have read [CONTRIBUTING.md][contributing].
- [x] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [x] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

