### PR TITLE
Handle stock reduction based on inventory tracking

### DIFF
--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -397,8 +397,8 @@ defmodule Snitch.Data.Model.Product do
   def product_with_inventory_tracking(product) do
     case is_child_product(product) do
       true ->
-        parent_product = Repo.preload(product, parent_variation: :parent_product)
-        parent_product.parent_variation.parent_product
+        product = Repo.preload(product, parent_variation: :parent_product)
+        product.parent_variation.parent_product
 
       false ->
         product

--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -390,6 +390,17 @@ defmodule Snitch.Data.Model.Product do
     end)
   end
 
+  def product_with_inventory_tracking(product) do
+    case is_child_product(product) do
+      true ->
+        parent_product = Repo.preload(product, parent_variation: :parent_product)
+        parent_product.parent_variation.parent_product
+
+      false ->
+        product
+    end
+  end
+
   @doc """
   Ordering of product depends on many things, for now we just check
   sufficient stock is available.

--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -390,6 +390,10 @@ defmodule Snitch.Data.Model.Product do
     end)
   end
 
+  @doc """
+  Returns the product that has the inventory tracking set on it.
+  """
+  @spec product_with_inventory_tracking(Product.t()) :: Product.t()
   def product_with_inventory_tracking(product) do
     case is_child_product(product) do
       true ->

--- a/apps/snitch_core/lib/core/domain/package.ex
+++ b/apps/snitch_core/lib/core/domain/package.ex
@@ -9,7 +9,7 @@ defmodule Snitch.Domain.Package do
   alias Ecto.Multi
   alias Snitch.Core.Tools.MultiTenancy.MultiQuery
   alias Snitch.Data.Schema.Package
-  alias Snitch.Domain.ShippingCalculator
+  alias Snitch.Domain.{ShippingCalculator, Inventory}
   alias Snitch.Tools.Money, as: MoneyTools
   alias Snitch.Data.Model.StockItem
   alias Snitch.Data.Model.GeneralConfiguration, as: GCModel
@@ -72,11 +72,7 @@ defmodule Snitch.Domain.Package do
     stock_location_id = package.origin_id
 
     Stream.map(package.items, fn item ->
-      stock_item =
-        StockItem.get(%{product_id: item.product_id, stock_location_id: stock_location_id})
-
-      count_on_hand = stock_item.count_on_hand - item.quantity
-      StockItem.update(%{count_on_hand: count_on_hand}, stock_item)
+      Inventory.reduce_stock(item.product_id, stock_location_id, item.quantity)
     end)
   end
 end

--- a/apps/snitch_core/lib/core/domain/stock/inventory.ex
+++ b/apps/snitch_core/lib/core/domain/stock/inventory.ex
@@ -45,7 +45,7 @@ defmodule Snitch.Domain.Inventory do
   `variant`
 
   When we track product by variant, the variant product stock is decreased.
-  > Note: Always pass the variant id to reduce the stock.
+  > Note: Always pass product id of the variant(product) to reduce the stock.
   """
   @spec reduce_stock(integer, integer, integer) ::
           {:ok, StockSchema.t()} | {:error, Ecto.Changeset.t() | :variant_not_found}

--- a/apps/snitch_core/lib/core/domain/stock/inventory.ex
+++ b/apps/snitch_core/lib/core/domain/stock/inventory.ex
@@ -27,8 +27,28 @@ defmodule Snitch.Domain.Inventory do
   end
 
   @doc """
-  Reduces stock for a product at particular stock location by the amount passed.
+  Decreases stock count for a product at particular stock location by the amount passed.
+
+  This method takes into consideration the inventory tracking level that is
+  applied on the product to reduce the stock.
+
+  `none`
+
+  When the inventory tracking for the product is `none`, we dont reduce the stock
+  for the product.
+
+  `product`
+
+  When we track inventory by product, we always reduce the stock of the product.
+  > Note: You can pass both variant or product id to reduce the stock.
+
+  `variant`
+
+  When we track product by variant, the variant product stock is decreased.
+  > Note: Always pass the variant id to reduce the stock.
   """
+  @spec reduce_stock(integer, integer, integer) ::
+          {:ok, StockSchema.t()} | {:error, Ecto.Changeset.t() | :variant_not_found}
   def reduce_stock(product_id, stock_location_id, reduce_count) do
     with product <- ProductModel.get(product_id),
          product_with_inventory <- ProductModel.product_with_inventory_tracking(product),

--- a/apps/snitch_core/test/domain/stock/inventory_test.exs
+++ b/apps/snitch_core/test/domain/stock/inventory_test.exs
@@ -122,4 +122,67 @@ defmodule Snitch.Domain.PackageItemTest do
              ]
     end
   end
+
+  describe "reduce_stock/3" do
+    test "stock not reduced for product with no inventory tracking" do
+      category = insert(:taxon)
+      stock_location = insert(:stock_location)
+      product = insert(:product, inventory_tracking: :none, taxon: category)
+
+      stock_item =
+        insert(:stock_item, count_on_hand: 5, product: product, stock_location: stock_location)
+
+      {:ok, stock} = Inventory.reduce_stock(product.id, stock_location.id, 2)
+
+      assert stock.count_on_hand == stock_item.count_on_hand
+    end
+
+    test "stock not reduced for product with variant and no inventory tracking" do
+      attrs = %{products: [build(:variant)], inventory_tracking: :none}
+      parent_product = insert(:product, attrs)
+      stock_location = insert(:stock_location)
+
+      stock_item =
+        insert(:stock_item,
+          count_on_hand: 5,
+          product: parent_product,
+          stock_location: stock_location
+        )
+
+      {:ok, stock} = Inventory.reduce_stock(parent_product.id, stock_location.id, 2)
+
+      assert stock.count_on_hand == stock_item.count_on_hand
+    end
+
+    test "stock reduced for product with product tracking" do
+      category = insert(:taxon)
+      stock_location = insert(:stock_location)
+      product = insert(:product, inventory_tracking: :product, taxon: category)
+
+      stock_item =
+        insert(:stock_item, count_on_hand: 5, product: product, stock_location: stock_location)
+
+      {:ok, stock} = Inventory.reduce_stock(product.id, stock_location.id, 2)
+
+      assert stock.count_on_hand == 3
+    end
+
+    test "stock reduced for product with variant and product tracking" do
+      variant = build(:variant)
+      attrs = %{products: [variant], inventory_tracking: :product}
+      parent_product = insert(:product, attrs)
+      stock_location = insert(:stock_location)
+
+      stock_item =
+        insert(:stock_item,
+          count_on_hand: 10,
+          product: parent_product,
+          stock_location: stock_location
+        )
+
+      {:ok, stock} = Inventory.reduce_stock(parent_product.id, stock_location.id, 2)
+
+      assert stock.count_on_hand == 8
+    end
+  end
 end

--- a/apps/snitch_core/test/support/factory/stock.ex
+++ b/apps/snitch_core/test/support/factory/stock.ex
@@ -32,7 +32,7 @@ defmodule Snitch.Factory.Stock do
         %StockItem{
           count_on_hand: 1,
           backorderable: false,
-          product: build(:product),
+          product: build(:product, inventory_tracking: :product),
           stock_location: build(:stock_location)
         }
       end


### PR DESCRIPTION
## Why?
Now that we are using inventory tracking, this changes how the stock will be reduced during order transitions.

## This change addresses the need by:
`core`
------
- Handle stock reduction in `Inventory` domain.

[delivers #162946249]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

