### PR TITLE
Refactors and adds autocompletion with fuzzy search

### DIFF
--- a/apps/admin_app/lib/admin_app_web/controllers/product_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/product_controller.ex
@@ -8,7 +8,7 @@ defmodule AdminAppWeb.ProductController do
   alias Snitch.Domain.Taxonomy
   alias Snitch.Tools.Helper.Rummage, as: RummageHelper
   alias Snitch.Domain.Inventory
-  alias Snitch.Tools.ElasticSearch.ProductStore, as: ESProductStore
+  alias Snitch.Tools.ElasticSearch.Product.Store, as: ESProductStore
 
   alias Snitch.Data.Schema.{
     ProductBrand,
@@ -19,8 +19,6 @@ defmodule AdminAppWeb.ProductController do
   }
 
   alias Snitch.Tools.Helper.Query
-  alias Snitch.Data.Model.StockItem, as: StockModel
-  alias Snitch.Data.Schema.StockItem, as: StockSchema
   alias Snitch.Data.Model.Image, as: ImageModel
   alias AdminAppWeb.ProductView
 

--- a/apps/snitch_api/lib/snitch_api/products_context/products_context.ex
+++ b/apps/snitch_api/lib/snitch_api/products_context/products_context.ex
@@ -4,7 +4,8 @@ defmodule SnitchApi.ProductsContext do
   """
   alias Snitch.Core.Tools.MultiTenancy.Repo
   alias Snitch.Data.Schema.{Product, Review}
-  alias Snitch.Tools.ElasticSearch.ProductSearch
+  alias Snitch.Tools.ElasticSearch.Product.Search, as: ProductSearch
+  alias Snitch.Tools.ElasticSearch.Product.Suggestor, as: ProductSuggestor
 
   import Ecto.Query
   # @filter_allowables ~w(taxon_id brand_id)a
@@ -41,5 +42,9 @@ defmodule SnitchApi.ProductsContext do
 
         {:ok, product}
     end
+  end
+
+  def suggest(query) do
+    ProductSuggestor.perform(query)
   end
 end

--- a/apps/snitch_api/lib/snitch_api_web/controllers/product_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/product_controller.ex
@@ -4,7 +4,8 @@ defmodule SnitchApiWeb.ProductController do
   alias Snitch.Data.Model.{Product, ProductReview}
   alias Snitch.Core.Tools.MultiTenancy.Repo
   alias SnitchApi.ProductsContext, as: Context
-  alias SnitchApiWeb.Elasticsearch.ProductView, as: ESPView
+  alias SnitchApiWeb.Elasticsearch.Product.ListView, as: ESPListView
+  alias SnitchApiWeb.Elasticsearch.Product.SuggestView, as: ESPSuggestView
 
   plug(SnitchApiWeb.Plug.DataToAttributes)
   action_fallback(SnitchApiWeb.FallbackController)
@@ -42,7 +43,7 @@ defmodule SnitchApiWeb.ProductController do
 
     json(
       conn,
-      JaSerializer.format(ESPView, products, conn,
+      JaSerializer.format(ESPListView, products, conn,
         page: page,
         meta: %{
           "aggregations" => aggregations,
@@ -69,4 +70,15 @@ defmodule SnitchApiWeb.ProductController do
         )
     end
   end
+
+  def suggest(conn, %{"q" => term}) do
+    suggestions = Context.suggest(term)
+
+    json(
+      conn,
+      JaSerializer.format(ESPSuggestView, suggestions, conn)
+    )
+  end
+
+  def suggest(conn, _), do: suggest(conn, %{"q" => ""})
 end

--- a/apps/snitch_api/lib/snitch_api_web/router.ex
+++ b/apps/snitch_api/lib/snitch_api_web/router.ex
@@ -21,6 +21,7 @@ defmodule SnitchApiWeb.Router do
     post("/login", UserController, :login)
     post("/orders/blank", OrderController, :guest_order)
     get("/variants/favorites", VariantController, :favorite_variants)
+    get("/products/suggest", ProductController, :suggest)
     resources("/products", ProductController, except: [:new, :edit], param: "product_slug")
     get("/orders/:order_number", OrderController, :fetch_guest_order)
     post("/hosted-payment/:payment_source/success", HostedPaymentController, :payment_success)

--- a/apps/snitch_api/lib/snitch_api_web/views/elasticsearch/product/list_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/elasticsearch/product/list_view.ex
@@ -1,4 +1,4 @@
-defmodule SnitchApiWeb.Elasticsearch.ProductView do
+defmodule SnitchApiWeb.Elasticsearch.Product.ListView do
   use SnitchApiWeb, :view
   use JaSerializer.PhoenixView
 

--- a/apps/snitch_api/lib/snitch_api_web/views/elasticsearch/product/suggest_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/elasticsearch/product/suggest_view.ex
@@ -1,0 +1,24 @@
+defmodule SnitchApiWeb.Elasticsearch.Product.SuggestView do
+  use SnitchApiWeb, :view
+  use JaSerializer.PhoenixView
+
+  attributes([
+    :id,
+    :name,
+    :brand,
+    :category
+  ])
+
+  defp source(product), do: product["_source"]
+
+  defp id(product) do
+    [_, id] = String.split(product["_id"], "_")
+    String.to_integer(id)
+  end
+
+  defp name(product), do: source(product)["name"]
+
+  defp brand(product), do: source(product)["brand"]
+
+  defp category(product), do: source(product)["category"]["direct_parent"]
+end

--- a/apps/snitch_api/test/snitch_api_web/controllers/product_controller_test.exs
+++ b/apps/snitch_api/test/snitch_api_web/controllers/product_controller_test.exs
@@ -7,7 +7,7 @@ defmodule SnitchApiWeb.ProductControllerTest do
   alias Snitch.Core.Tools.MultiTenancy.Repo
   alias Snitch.Tools.ElasticsearchCluster, as: ESCluster
   alias Elasticsearch.{Index, Cluster}
-  alias Snitch.Tools.ElasticSearch.ProductStore
+  alias Snitch.Tools.ElasticSearch.Product.Store, as: ProductStore
 
   setup %{conn: conn} do
     Elasticsearch.delete(ESCluster, "products_test")

--- a/apps/snitch_api/test/support/settings/products.json
+++ b/apps/snitch_api/test/support/settings/products.json
@@ -85,10 +85,12 @@
         },
         "suggest_keywords": {
           "type": "completion",
-          "analyzer": "simple",
-          "preserve_separators": false,
-          "preserve_position_increments": true,
-          "max_input_length": 50
+          "contexts": [
+            { 
+                "name": "tenant",
+                "type": "category"
+            }
+          ]
         },
         "name": {
           "type": "text"

--- a/apps/snitch_core/config/config.exs
+++ b/apps/snitch_core/config/config.exs
@@ -40,7 +40,7 @@ config :snitch_core, Snitch.Tools.ElasticsearchCluster,
   indexes: %{
     products: %{
       settings: "priv/elasticsearch/products.json",
-      store: Snitch.Tools.ElasticSearch.ProductStore,
+      store: Snitch.Tools.ElasticSearch.Product.Store,
       sources: [Snitch.Data.Schema.Product],
       bulk_page_size: 5000,
       bulk_wait_interval: 15_000

--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -11,7 +11,7 @@ defmodule Snitch.Data.Model.Product do
   alias Snitch.Data.Schema.{Image, Product, Variation, Taxon}
   alias Snitch.Tools.Helper.ImageUploader
   alias Snitch.Core.Tools.MultiTenancy.Repo
-  alias Snitch.Tools.ElasticSearch.ProductStore, as: ESProductStore
+  alias Snitch.Tools.ElasticSearch.Product.Store, as: ESProductStore
 
   @product_states [:active, :in_active, :draft]
 

--- a/apps/snitch_core/lib/core/data/model/product_review.ex
+++ b/apps/snitch_core/lib/core/data/model/product_review.ex
@@ -6,7 +6,7 @@ defmodule Snitch.Data.Model.ProductReview do
   alias Ecto.Multi
   use Snitch.Data.Model
   alias Snitch.Data.Schema.{ProductReview, RatingOption, Review, Product}
-  alias Snitch.Tools.ElasticSearch.ProductStore, as: ESProductStore
+  alias Snitch.Tools.ElasticSearch.Product.Store, as: ESProductStore
 
   @review_detail %{
     average_rating: 0,

--- a/apps/snitch_core/lib/core/tools/elasticsearch/product/document.ex
+++ b/apps/snitch_core/lib/core/tools/elasticsearch/product/document.ex
@@ -151,9 +151,26 @@ defimpl Elasticsearch.Document, for: Snitch.Data.Schema.Product do
     }
   end
 
-  defp suggest_keywords(%{name: name, meta_keywords: meta_keywords}) do
-    keywords = String.split(name, ~r(\s+)) ++ String.split(meta_keywords || "", ~r(\s*\,\s*))
-    Enum.filter(keywords, &("" != &1))
+  defp suggest_keywords(%{name: name, meta_keywords: meta_keywords, tenant: tenant}) do
+    keywords =
+      "#{name} #{meta_keywords}"
+      |> String.trim()
+      |> String.downcase()
+      |> String.split(~r(\s+|\s*\,\s*))
+
+    %{
+      "input" => format_suggest_input(keywords),
+      "contexts" => %{
+        "tenant" => tenant
+      }
+    }
+  end
+
+  defp format_suggest_input([]), do: []
+
+  defp format_suggest_input(keywords) do
+    [h | t] = keywords
+    [h <> " " <> Enum.join(t, " ") | format_suggest_input(t)]
   end
 
   defp format_money(money) do

--- a/apps/snitch_core/lib/core/tools/elasticsearch/product/search.ex
+++ b/apps/snitch_core/lib/core/tools/elasticsearch/product/search.ex
@@ -1,4 +1,4 @@
-defmodule Snitch.Tools.ElasticSearch.ProductSearch do
+defmodule Snitch.Tools.ElasticSearch.Product.Search do
   @moduledoc """
   Product Search using elasticsearch
 
@@ -11,7 +11,7 @@ defmodule Snitch.Tools.ElasticSearch.ProductSearch do
   """
   alias Snitch.Core.Tools.MultiTenancy.Repo
 
-  import Snitch.Tools.ElasticSearch.ProductStore, only: [search_products: 1]
+  import Snitch.Tools.ElasticSearch.Product.Store, only: [search_products: 1]
 
   def run(conn, params) do
     %{

--- a/apps/snitch_core/lib/core/tools/elasticsearch/product/store.ex
+++ b/apps/snitch_core/lib/core/tools/elasticsearch/product/store.ex
@@ -1,4 +1,4 @@
-defmodule Snitch.Tools.ElasticSearch.ProductStore do
+defmodule Snitch.Tools.ElasticSearch.Product.Store do
   @moduledoc """
   Fetches data from product table to be used in product index
   """

--- a/apps/snitch_core/lib/core/tools/elasticsearch/product/suggestor.ex
+++ b/apps/snitch_core/lib/core/tools/elasticsearch/product/suggestor.ex
@@ -1,0 +1,48 @@
+defmodule Snitch.Tools.ElasticSearch.Product.Suggestor do
+  @moduledoc """
+  Product Suggestion using elasticsearch
+
+  Architecture reference : https://project-a.github.io/on-site-search-design-patterns-for-e-commerce/#index-pages-not-products
+  """
+
+  import Snitch.Tools.ElasticSearch.Product.Store, only: [search_products: 1]
+  alias Snitch.Core.Tools.MultiTenancy.Repo
+
+  def perform(term) do
+    %{
+      "suggest" => %{
+        "product-suggest" => [
+          %{
+            "options" => collection
+          }
+          | _
+        ]
+      }
+    } =
+      term
+      |> convert_to_elastic_query
+      |> search_products
+
+    collection
+  end
+
+  defp convert_to_elastic_query(term) do
+    %{
+      "_source" => ["name", "brands", "category.direct_parent"],
+      "suggest" => %{
+        "product-suggest" => %{
+          "prefix" => term,
+          "completion" => %{
+            "field" => "suggest_keywords",
+            "size" => "10",
+            "fuzzy" =>  true,
+            "skip_duplicates" => "true",
+            "contexts" => %{
+              "tenant" => Repo.get_prefix()
+            }
+          }
+        }
+      }
+    }
+  end
+end

--- a/apps/snitch_core/priv/elasticsearch/products.json
+++ b/apps/snitch_core/priv/elasticsearch/products.json
@@ -85,10 +85,12 @@
         },
         "suggest_keywords": {
           "type": "completion",
-          "analyzer": "simple",
-          "preserve_separators": false,
-          "preserve_position_increments": true,
-          "max_input_length": 50
+          "contexts": [
+            { 
+                "name": "tenant",
+                "type": "category"
+            }
+          ]
         },
         "name": {
           "type": "text"


### PR DESCRIPTION
## Why?
- Need to have an API for autocompletion, to allow typeahead suggestion on the frontend search bar.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
- Adds `suggest` route for product suggestion.
- Restructure elasticsearch folder for product-related functions.
- adds product suggestion module to be called from product context for suggestions
<!--- List and detail all changes made in this PR. -->

[delivers #163019455]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

