### PR TITLE
Add check for inventory tracking for is_orderable

### DIFF
--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -415,7 +415,24 @@ defmodule Snitch.Data.Model.Product do
   """
   @spec is_orderable?(Product.t()) :: true | false
   def is_orderable?(product) do
-    has_stock?(product)
+    with product_with_tracking <- product_with_inventory_tracking(product) do
+      case product_with_tracking.inventory_tracking do
+        :none ->
+          true
+
+        :product ->
+          case is_child_product(product) do
+            true ->
+              has_stock?(product_with_tracking)
+
+            false ->
+              has_stock?(product)
+          end
+
+        :variant ->
+          has_stock?(product)
+      end
+    end
   end
 
   defp has_stock?(product) do

--- a/apps/snitch_core/lib/core/tools/elasticsearch/product/suggestor.ex
+++ b/apps/snitch_core/lib/core/tools/elasticsearch/product/suggestor.ex
@@ -35,7 +35,7 @@ defmodule Snitch.Tools.ElasticSearch.Product.Suggestor do
           "completion" => %{
             "field" => "suggest_keywords",
             "size" => "10",
-            "fuzzy" =>  true,
+            "fuzzy" => true,
             "skip_duplicates" => "true",
             "contexts" => %{
               "tenant" => Repo.get_prefix()

--- a/apps/snitch_core/test/data/model/product_test.exs
+++ b/apps/snitch_core/test/data/model/product_test.exs
@@ -289,15 +289,88 @@ defmodule Snitch.Data.Model.ProductTest do
     end
   end
 
-  describe "is orderable" do
-    test "when product with no stock items" do
-      product = insert(:product)
-      refute Product.is_orderable?(product)
+  describe "is orderable?/1" do
+    test "simple product and no product tracking" do
+      product = insert(:product, inventory_tracking: :none)
+
+      assert Product.is_orderable?(product)
     end
 
-    test "when product with stock items" do
-      stock_movement = insert(:stock_movement) |> Repo.preload(stock_item: :product)
-      assert Product.is_orderable?(stock_movement.stock_item.product)
+    test "product with variant and no product tracking" do
+      attrs = %{products: [build(:variant)], inventory_tracking: :none}
+      parent_product = insert(:product, attrs)
+      variant = parent_product.products |> List.first()
+
+      assert Product.is_orderable?(parent_product)
+      assert Product.is_orderable?(variant)
+    end
+
+    test "simple product with inventory tracking by product" do
+      product = insert(:product, inventory_tracking: :product)
+
+      # Product has no stock
+      refute Product.is_orderable?(product)
+
+      stock_location = insert(:stock_location)
+
+      stock_item =
+        insert(:stock_item,
+          count_on_hand: 10,
+          product: product,
+          stock_location: stock_location
+        )
+
+      # product has stock
+      assert Product.is_orderable?(product)
+    end
+
+    test "product with variants and inventory tracking by product" do
+      attrs = %{products: [build(:variant)], inventory_tracking: :product}
+      parent_product = insert(:product, attrs)
+      variant = parent_product.products |> List.first()
+
+      refute Product.is_orderable?(parent_product)
+
+      stock_location = insert(:stock_location)
+
+      stock_item =
+        insert(:stock_item,
+          count_on_hand: 10,
+          product: parent_product,
+          stock_location: stock_location
+        )
+
+      # product has stock
+      assert Product.is_orderable?(parent_product)
+
+      # variant product will also be orderable as inventory is tracked by parent
+      # product
+      assert Product.is_orderable?(variant)
+    end
+
+    test "product with variants and inventory tracking by variant" do
+      attrs = %{products: [build(:variant)], inventory_tracking: :variant}
+      parent_product = insert(:product, attrs)
+      variant = parent_product.products |> List.first()
+
+      refute Product.is_orderable?(parent_product)
+
+      # variant product does not have stock
+      refute Product.is_orderable?(variant)
+
+      stock_location = insert(:stock_location)
+
+      stock_item =
+        insert(:stock_item,
+          count_on_hand: 10,
+          product: variant,
+          stock_location: stock_location
+        )
+
+      refute Product.is_orderable?(parent_product)
+
+      # variant product does not have stock
+      assert Product.is_orderable?(variant)
     end
   end
 


### PR DESCRIPTION
## Why?
Frontstore depends on `is_orderable` field for disabling a product to be added in cart. Inventory tracking will change the behavior of this field.

## This change addresses the need by:
`core`
------
- Change the definition of `Snitch.Data.Model.Product.is_orderable/1` as per inventory tracking.

[delivers #pivotal_story_id]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

