### PR TITLE
Fix stock API failure on variant edit page

### DIFF
--- a/apps/admin_app/assets/js/views/product/edit.js
+++ b/apps/admin_app/assets/js/views/product/edit.js
@@ -117,7 +117,8 @@ export function handleStockForProductTracking() {
   let stockLocationId = $("#product_tracking #stock_stock_location_id").val();
   let productId = $("#product_tracking #stock_product_id").val();
 
-  getStockForProductLevel(productId, stockLocationId);
+  if(stockLocationId && productId)
+    getStockForProductLevel(productId, stockLocationId);
 
   $("#product_tracking #stock_stock_location_id").on("change", function() {
     let stockLocationId = this.value;

--- a/apps/admin_app/assets/js/views/product/edit.js
+++ b/apps/admin_app/assets/js/views/product/edit.js
@@ -16,11 +16,17 @@ export default class View extends MainView {
     setVariantState();
     switchVariantState();
     addEventToProductFormButtons();
-    setSelectedInventoryTracking();
-    setupProductTracking();
-    handleInventoryTrackingToggle();
-    handleStockForProductTracking();
-    handleStockForVariantTracking();
+
+    if ($("#inventory_tab").length) {
+      setSelectedInventoryTracking();
+      setupProductTracking();
+      handleInventoryTrackingToggle();
+    }
+
+    if ($("#options_tab").length) {
+      handleStockForProductTracking();
+      handleStockForVariantTracking();
+    }
   }
 
   unmount() {
@@ -117,7 +123,7 @@ export function handleStockForProductTracking() {
   let stockLocationId = $("#product_tracking #stock_stock_location_id").val();
   let productId = $("#product_tracking #stock_product_id").val();
 
-  if(stockLocationId && productId)
+  if (stockLocationId && productId)
     getStockForProductLevel(productId, stockLocationId);
 
   $("#product_tracking #stock_stock_location_id").on("change", function() {


### PR DESCRIPTION
## Why?
Variant edit page would make API call for stock information and fail.

## This change addresses the need by:
- Fixed the JS to not make API call on the variant edit page.

[delivers #163080116]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

