### PR TITLE
Assets and Elastic Search error in docker

### DIFF
--- a/apps/snitch_core/config/dev.exs
+++ b/apps/snitch_core/config/dev.exs
@@ -6,7 +6,7 @@ config :snitch_core, Snitch.Repo,
   username: "postgres",
   password: "postgres",
   database: "snitch_dev",
-  hostname: "db",
+  hostname: System.get_env("DB_HOST"),
   pool_size: 10
 
 config :snitch_core, :defaults_module, Snitch.Tools.Defaults

--- a/apps/snitch_core/config/dev.exs
+++ b/apps/snitch_core/config/dev.exs
@@ -6,7 +6,7 @@ config :snitch_core, Snitch.Repo,
   username: "postgres",
   password: "postgres",
   database: "snitch_dev",
-  hostname: "localhost",
+  hostname: "db",
   pool_size: 10
 
 config :snitch_core, :defaults_module, Snitch.Tools.Defaults

--- a/config/docker/dev/Dockerfile-dev
+++ b/config/docker/dev/Dockerfile-dev
@@ -37,7 +37,7 @@ RUN apt-get clean \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && curl -sL https://deb.nodesource.com/setup_8.x | bash \
   && apt-get install -y nodejs yarn
-  
+
 # Umbrella
 COPY mix.exs mix.lock ./
 COPY config config
@@ -70,9 +70,8 @@ RUN apt-get clean \
 
 
 RUN cd apps/admin_app/assets \
-    && yarn install
+  && yarn install
 
 RUN ["chmod", "+x", "./config/docker/dev/docker-dev-provision.sh"]
 
 CMD ["./config/docker/dev/docker-dev-provision.sh"]
-

--- a/config/docker/dev/Dockerfile-dev
+++ b/config/docker/dev/Dockerfile-dev
@@ -19,6 +19,7 @@ ENV HOSTED_PAYMENT_URL http://localhost:3000/api/v1/hosted-payment/
 ENV SUPPORT_URL https://admin.aviacommerce.org
 ENV WKHTML_PATH /usr/bin/wkhtmltopdf
 ENV ELASTIC_HOST http://localhost:9200/
+ENV DB_HOST db
 
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME

--- a/config/docker/dev/Dockerfile-dev
+++ b/config/docker/dev/Dockerfile-dev
@@ -37,7 +37,7 @@ RUN apt-get clean \
   && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
   && curl -sL https://deb.nodesource.com/setup_8.x | bash \
   && apt-get install -y nodejs yarn
-
+  
 # Umbrella
 COPY mix.exs mix.lock ./
 COPY config config
@@ -67,6 +67,10 @@ RUN apt-get clean \
   && apt-get purge -y curl file xz-utils build-essential locales \
   && apt-get -y autoremove \
   && apt-get -y clean
+
+
+RUN cd apps/admin_app/assets \
+    && yarn install
 
 RUN ["chmod", "+x", "./config/docker/dev/docker-dev-provision.sh"]
 

--- a/config/docker/dev/docker-compose-dev.yml
+++ b/config/docker/dev/docker-compose-dev.yml
@@ -28,6 +28,9 @@ services:
       memlock:
         soft: -1
         hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536 
     ports:
       - "9200:9200"
   kibana:

--- a/config/docker/dev/docker-compose-dev.yml
+++ b/config/docker/dev/docker-compose-dev.yml
@@ -1,4 +1,4 @@
-version: '3' 
+version: '3'
 services:
   webapp:
     build:
@@ -30,7 +30,7 @@ services:
         hard: -1
       nofile:
         soft: 65536
-        hard: 65536 
+        hard: 65536
     ports:
       - "9200:9200"
   kibana:
@@ -38,4 +38,3 @@ services:
     ports:
       - "5601:5601"
     container_name: kibana
-

--- a/env/local.env.remove_me
+++ b/env/local.env.remove_me
@@ -20,6 +20,7 @@ export SENDGRID_SENDER_EMAIL=hello@aviabird.com
 export FRONTEND_URL=http://localhost:4200/
 export BACKEND_URL=http://localhost:4000/
 export ELASTIC_HOST=http://localhost:9200/
+export DB_HOST=localhost
 
 
 # Keys for Avia app to import products

--- a/env/test.env
+++ b/env/test.env
@@ -20,6 +20,7 @@ export SENDGRID_SENDER_EMAIL=
 export FRONTEND_URL=http://localhost:4200/
 export BACKEND_URL=http://localhost:4000/
 export ELASTIC_HOST=http://localhost:9200/
+export DB_HOST=localhost
 
 
 # Keys for Avia app to import products


### PR DESCRIPTION
  **Motivation and Context**
 
 Docker setup of Aviacommerce on Linux machine is facing the below two problems
   + Elastic Search was exiting with code 78. This was due to low 'max file descriptor size' and low 'max 
        virtual memory'.
   + Assets were not getting installed automatically. 


  **Describe your changes**
   + Made changes in Dockerfile-dev to resolve the assets problem.
   + Made changes in  docker-compose-dev.yml to resolve elastic search problem as it
    was getting stopped due to low descriptor size

## Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
<!--- List and detail all changes made in this PR. -->

[delivers #162446059]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

