### PR TITLE
Caching Taxonomy and search responses as per the url

### DIFF
--- a/apps/snitch_api/lib/snitch_api_web/controllers/product_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/product_controller.ex
@@ -81,7 +81,15 @@ defmodule SnitchApiWeb.ProductController do
   end
 
   def suggest(conn, %{"q" => term}) do
-    suggestions = Context.suggest(term)
+    suggestions =
+      Cache.get(
+        current_url(conn),
+        {
+          fn term -> Context.suggest(term) end,
+          [term]
+        },
+        :timer.minutes(15)
+      )
 
     json(
       conn,

--- a/apps/snitch_api/lib/snitch_api_web/controllers/product_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/product_controller.ex
@@ -6,6 +6,7 @@ defmodule SnitchApiWeb.ProductController do
   alias SnitchApi.ProductsContext, as: Context
   alias SnitchApiWeb.Elasticsearch.Product.ListView, as: ESPListView
   alias SnitchApiWeb.Elasticsearch.Product.SuggestView, as: ESPSuggestView
+  alias Snitch.Tools.Cache
 
   plug(SnitchApiWeb.Plug.DataToAttributes)
   action_fallback(SnitchApiWeb.FallbackController)
@@ -39,7 +40,15 @@ defmodule SnitchApiWeb.ProductController do
   variants.options,variants.options.option_type,options,options.option_type,
   theme,theme.option_types,reviews.rating_option_vote.rating_option)
   def index(conn, params) do
-    {products, page, aggregations, total} = Context.list_products(conn, params)
+    {products, page, aggregations, total} =
+      Cache.get(
+        current_url(conn),
+        {
+          fn conn, params -> Context.list_products(conn, params) end,
+          [conn, params]
+        },
+        :timer.minutes(15)
+      )
 
     json(
       conn,

--- a/apps/snitch_api/lib/snitch_api_web/controllers/taxonomy_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/taxonomy_controller.ex
@@ -5,27 +5,21 @@ defmodule SnitchApiWeb.TaxonomyController do
   alias Snitch.Core.Tools.MultiTenancy.Repo
 
   alias Snitch.Domain.Taxonomy, as: TaxonomyDomain
-  alias Cachex
-
-  @cache_name :avia_cache
+  alias Snitch.Tools.Cache
 
   action_fallback(SnitchApiWeb.FallbackController)
   plug(SnitchApiWeb.Plug.DataToAttributes)
   plug(SnitchApiWeb.Plug.LoadUser)
 
   def index(conn, _params) do
-    cache_key = Repo.get_prefix() <> "_taxonomy_list_for_api"
-
     taxonomy =
-      with {:ok, value} <- Cachex.get(@cache_name, cache_key),
-           false <- is_nil(value) do
-        value
-      else
-        _ ->
-          taxonomy = TaxonomyDomain.get_all_taxonomy()
-          Cachex.put(@cache_name, cache_key, taxonomy, ttl: :timer.hours(2))
-          taxonomy
-      end
+      Cache.get(
+        current_url(conn),
+        {
+          fn -> TaxonomyDomain.get_all_taxonomy() end,
+          []
+        }
+      )
 
     json(conn, %{taxonomies: taxonomy})
   end

--- a/apps/snitch_api/lib/snitch_api_web/controllers/taxonomy_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/taxonomy_controller.ex
@@ -5,13 +5,28 @@ defmodule SnitchApiWeb.TaxonomyController do
   alias Snitch.Core.Tools.MultiTenancy.Repo
 
   alias Snitch.Domain.Taxonomy, as: TaxonomyDomain
+  alias Cachex
+
+  @cache_name :avia_cache
 
   action_fallback(SnitchApiWeb.FallbackController)
   plug(SnitchApiWeb.Plug.DataToAttributes)
   plug(SnitchApiWeb.Plug.LoadUser)
 
   def index(conn, _params) do
-    taxonomy = TaxonomyDomain.get_all_taxonomy()
+    cache_key = Repo.get_prefix() <> "_taxonomy_list_for_api"
+
+    taxonomy =
+      with {:ok, value} <- Cachex.get(@cache_name, cache_key),
+           false <- is_nil(value) do
+        value
+      else
+        _ ->
+          taxonomy = TaxonomyDomain.get_all_taxonomy()
+          Cachex.put(@cache_name, cache_key, taxonomy, ttl: :timer.hours(2))
+          taxonomy
+      end
+
     json(conn, %{taxonomies: taxonomy})
   end
 

--- a/apps/snitch_core/lib/core/application.ex
+++ b/apps/snitch_core/lib/core/application.ex
@@ -14,7 +14,7 @@ defmodule Snitch.Application do
         [
           supervisor(Snitch.Repo, []),
           supervisor(Snitch.Tools.ElasticsearchCluster, []),
-          worker(Cachex, [:snitch_cache, []])
+          worker(Cachex, [:avia_cache, []])
         ],
         strategy: :one_for_one,
         name: Snitch.Supervisor

--- a/apps/snitch_core/lib/core/application.ex
+++ b/apps/snitch_core/lib/core/application.ex
@@ -14,7 +14,7 @@ defmodule Snitch.Application do
         [
           supervisor(Snitch.Repo, []),
           supervisor(Snitch.Tools.ElasticsearchCluster, []),
-          worker(Cachex, [:avia_cache, []])
+          worker(Cachex, [:avia_cache, [limit: 1000]])
         ],
         strategy: :one_for_one,
         name: Snitch.Supervisor

--- a/apps/snitch_core/lib/core/tools/cache.ex
+++ b/apps/snitch_core/lib/core/tools/cache.ex
@@ -1,0 +1,24 @@
+defmodule Snitch.Tools.Cache do
+  @moduledoc """
+  Helper for caching data
+  """
+
+  @cache_name :avia_cache
+
+  @doc """
+  Fetches the data
+  * from cache if exists.
+  * from the callback function `fun` returning the data
+  """
+  def get(cache_key, {fun, args}, expiry \\ :timer.hours(2)) do
+    with {:ok, value} <- Cachex.get(@cache_name, cache_key),
+           false <- is_nil(value) do
+        value
+      else
+        _ ->
+          result = apply(fun, args)
+          Cachex.put(@cache_name, cache_key, result, ttl: expiry)
+          result
+      end
+  end
+end


### PR DESCRIPTION
## Why?
- some API request needed to be cached, like category, elasticsearch responses.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
- Adds a `cache` tool in `snitch_core` which can be called from anywhere to retrieve the cached result.
- Added cache support to taxonomy api, product listing, product search autocompletion.
<!--- List and detail all changes made in this PR. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

