### PR TITLE
Add upn number to uniquely identify products

### DIFF
--- a/apps/snitch_api/lib/snitch_api_web/views/product_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/product_view.ex
@@ -19,6 +19,7 @@ defmodule SnitchApiWeb.ProductView do
     :deleted_at,
     :discontinue_on,
     :slug,
+    :upn,
     :meta_description,
     :meta_keywords,
     :meta_title,

--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -513,6 +513,19 @@ defmodule Snitch.Data.Model.Product do
   end
 
   def upn_generate() do
-    "A" <> Nanoid.generate(10, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ") <> "C"
+    upn = "A" <> Nanoid.generate(10, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ") <> "C"
+
+    case is_upn_unique(upn) do
+      true ->
+        upn
+
+      false ->
+        upn_generate()
+    end
+  end
+
+  defp is_upn_unique(upn) do
+    is_present = from(p in "snitch_products", select: p.upn, where: p.upn == ^upn) |> Repo.one()
+    if is_present == nil, do: true, else: false
   end
 end

--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -513,8 +513,14 @@ defmodule Snitch.Data.Model.Product do
     Product.is_variant_tracking_enabled?(product)
   end
 
+  # to be mocked
+  def gen_nano_id() do
+    Nanoid.generate(10, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
+  end
+
+  # TODO: write test case for this
   def upn_generate() do
-    upn = "A" <> Nanoid.generate(10, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ") <> "C"
+    upn = "A" <> gen_nano_id() <> "C"
 
     case get_product_with_upn(upn) do
       nil ->

--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -511,4 +511,8 @@ defmodule Snitch.Data.Model.Product do
   def is_variant_tracking_enabled?(product) do
     Product.is_variant_tracking_enabled?(product)
   end
+
+  def upn_generate() do
+    "A" <> Nanoid.generate(10, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ") <> "C"
+  end
 end

--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -15,6 +15,7 @@ defmodule Snitch.Data.Model.Product do
 
   @product_states [:active, :in_active, :draft]
 
+  @callback generate_upn() :: string()
   @doc """
   Returns all Products
   """
@@ -515,17 +516,16 @@ defmodule Snitch.Data.Model.Product do
   def upn_generate() do
     upn = "A" <> Nanoid.generate(10, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ") <> "C"
 
-    case is_upn_unique(upn) do
-      true ->
+    case get_product_with_upn(upn) do
+      nil ->
         upn
 
-      false ->
+      _ ->
         upn_generate()
     end
   end
 
-  defp is_upn_unique(upn) do
-    is_present = from(p in "snitch_products", select: p.upn, where: p.upn == ^upn) |> Repo.one()
-    if is_present == nil, do: true, else: false
+  defp get_product_with_upn(upn) do
+    from(p in "snitch_products", select: p.upn, where: p.upn == ^upn) |> Repo.one()
   end
 end

--- a/apps/snitch_core/lib/core/data/schema/product.ex
+++ b/apps/snitch_core/lib/core/data/schema/product.ex
@@ -162,8 +162,6 @@ defmodule Snitch.Data.Schema.Product do
     |> validate_amount(:selling_price)
     |> NameSlug.maybe_generate_slug()
     |> unique_constraint(:upn)
-
-    # |> NameSlug.unique_constraint()
   end
 
   def product_by_category_query(taxon_id) do

--- a/apps/snitch_core/lib/core/data/schema/product.ex
+++ b/apps/snitch_core/lib/core/data/schema/product.ex
@@ -161,7 +161,7 @@ defmodule Snitch.Data.Schema.Product do
     |> validate_required(@required_fields)
     |> validate_amount(:selling_price)
     |> NameSlug.maybe_generate_slug()
-    |> unique_constraint(:upn)
+    |> unique_constraint(:upn, message: "Ooops, another product already has that name!")
   end
 
   def product_by_category_query(taxon_id) do

--- a/apps/snitch_core/lib/core/data/schema/product.ex
+++ b/apps/snitch_core/lib/core/data/schema/product.ex
@@ -8,6 +8,7 @@ defmodule Snitch.Data.Schema.Product do
 
   import Ecto.Query
 
+  alias Snitch.Data.Model.Product, as: ProductModel
   alias Snitch.Data.Schema.Product.NameSlug
   alias Snitch.Domain.Taxonomy
 
@@ -34,6 +35,12 @@ defmodule Snitch.Data.Schema.Product do
     field(:deleted_at, :utc_datetime)
     field(:discontinue_on, :utc_datetime)
     field(:slug, :string)
+
+    # unique product number(upn) to indentify a product uniquely
+    # just like amazon uses asin (Amazon Standard Identification Number)
+    # for unique identification of products.
+    field(:upn, :string, autogenerate: {ProductModel, :upn_generate, []})
+
     field(:meta_description, :string)
     field(:meta_keywords, :string)
     field(:meta_title, :string)
@@ -154,7 +161,9 @@ defmodule Snitch.Data.Schema.Product do
     |> validate_required(@required_fields)
     |> validate_amount(:selling_price)
     |> NameSlug.maybe_generate_slug()
-    |> NameSlug.unique_constraint()
+    |> unique_constraint(:upn)
+
+    # |> NameSlug.unique_constraint()
   end
 
   def product_by_category_query(taxon_id) do

--- a/apps/snitch_core/mix.exs
+++ b/apps/snitch_core/mix.exs
@@ -76,6 +76,7 @@ defmodule Snitch.Core.Mixfile do
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:excoveralls, "~> 0.8.2", only: :test},
       {:mox, "~> 0.3", only: :test},
+      {:mock, "~> 0.3.0", only: :test},
       {:ex_machina, "~> 2.2", only: :test},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:inch_ex, "~> 0.5.6", only: [:docs, :dev]},

--- a/apps/snitch_core/priv/repo/migrations/20190115093617_add_upn_field_to_products.exs
+++ b/apps/snitch_core/priv/repo/migrations/20190115093617_add_upn_field_to_products.exs
@@ -6,7 +6,6 @@ defmodule Snitch.Repo.Migrations.AddUpnFieldToProducts do
       add(:upn, :string)
     end
 
-    drop unique_index("snitch_products", [:slug])
     create unique_index("snitch_products", [:upn])
   end
 end

--- a/apps/snitch_core/priv/repo/migrations/20190115093617_add_upn_field_to_products.exs
+++ b/apps/snitch_core/priv/repo/migrations/20190115093617_add_upn_field_to_products.exs
@@ -1,0 +1,12 @@
+defmodule Snitch.Repo.Migrations.AddUpnFieldToProducts do
+  use Ecto.Migration
+
+  def change do
+    alter table("snitch_products") do
+      add(:upn, :string)
+    end
+
+    drop unique_index("snitch_products", [:slug])
+    create unique_index("snitch_products", [:upn])
+  end
+end

--- a/apps/snitch_core/test/data/model/product_test.exs
+++ b/apps/snitch_core/test/data/model/product_test.exs
@@ -152,6 +152,24 @@ defmodule Snitch.Data.Model.ProductTest do
     end
   end
 
+  describe "upn generation for a product" do
+    setup do
+      product = insert(:product)
+      [product: product]
+    end
+
+    test "if no matching upn exists", %{product: product, valid_params: vp} do
+      {:ok, %ProductSchema{} = new_product} = Product.create(vp)
+      assert product.upn != new_product.upn
+    end
+
+    test "if a duplicate upn exists", %{product: product} do
+      assert_raise Ecto.ConstraintError, fn ->
+        insert(:product, %{upn: product.upn})
+      end
+    end
+  end
+
   describe "sellable products list" do
     test "if product has no variants" do
       assert [%ProductSchema{}] = Product.sellable_products_query() |> Repo.all()

--- a/apps/snitch_core/test/data/model/product_test.exs
+++ b/apps/snitch_core/test/data/model/product_test.exs
@@ -150,11 +150,6 @@ defmodule Snitch.Data.Model.ProductTest do
     test "successfully", %{valid_params: vp} do
       assert {:ok, %ProductSchema{}} = Product.create(vp)
     end
-
-    test "creation fails for duplicate product", %{valid_params: vp} do
-      Product.create(vp)
-      assert {:error, _} = Product.create(vp)
-    end
   end
 
   describe "sellable products list" do

--- a/apps/snitch_core/test/data/model/product_test.exs
+++ b/apps/snitch_core/test/data/model/product_test.exs
@@ -169,14 +169,6 @@ defmodule Snitch.Data.Model.ProductTest do
         insert(:product, %{upn: product.upn})
       end
     end
-
-    test "if a upn has already been taken", %{valid_params: vp} do
-      with_mock Product, upn_generate: fn -> Enum.random(["AB07BWBCJXKC", "AB074P14F76C"]) end do
-        upn1 = Product.upn_generate()
-        upn2 = Product.upn_generate()
-        refute upn1 == upn2
-      end
-    end
   end
 
   describe "sellable products list" do

--- a/apps/snitch_core/test/data/model/product_test.exs
+++ b/apps/snitch_core/test/data/model/product_test.exs
@@ -2,6 +2,7 @@ defmodule Snitch.Data.Model.ProductTest do
   use ExUnit.Case
   use Snitch.DataCase
   import Snitch.Factory
+  import Mock
   alias Snitch.Data.Model.Product
   alias Snitch.Data.Schema.Product, as: ProductSchema
   alias Snitch.Data.Schema.{Variation, Image}
@@ -163,9 +164,17 @@ defmodule Snitch.Data.Model.ProductTest do
       assert product.upn != new_product.upn
     end
 
-    test "if a duplicate upn exists", %{product: product} do
+    test "if a product with generated upn exists", %{product: product} do
       assert_raise Ecto.ConstraintError, fn ->
         insert(:product, %{upn: product.upn})
+      end
+    end
+
+    test "if a upn has already been taken", %{valid_params: vp} do
+      with_mock Product, upn_generate: fn -> Enum.random(["AB07BWBCJXKC", "AB074P14F76C"]) end do
+        upn1 = Product.upn_generate()
+        upn2 = Product.upn_generate()
+        refute upn1 == upn2
       end
     end
   end


### PR DESCRIPTION
## Why?
Instead of using just slug to uniquely identify products, we are using upn (unique product number) analogous to amazon's asin number.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
1. Use unique number(upn) for products instead of slug to uniquely identify them.
2. Added upn field to product schema.

Migration added:
20190115093617_add_upn_field_to_products.exs
<!--- List and detail all changes made in this PR. -->

[finishes  #163114687](https://www.pivotaltracker.com/story/show/163114687)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

