### PR TITLE
test upi generation function

### DIFF
--- a/apps/snitch_api/lib/snitch_api_web/views/product_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/product_view.ex
@@ -19,7 +19,7 @@ defmodule SnitchApiWeb.ProductView do
     :deleted_at,
     :discontinue_on,
     :slug,
-    :upn,
+    :upi,
     :meta_description,
     :meta_keywords,
     :meta_title,

--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -520,7 +520,7 @@ defmodule Snitch.Data.Model.Product do
   def generate_upi() do
     upi = "A" <> gen_nano_id() <> "C"
 
-    case upi_generate(upi) do
+    case get_upi_if_unique(upi) do
       {:error, _} ->
         generate_upi()
 
@@ -530,7 +530,7 @@ defmodule Snitch.Data.Model.Product do
   end
 
   # TODO: write test case for this
-  def upi_generate(upi) do
+  def get_upi_if_unique(upi) do
     case get_product_with_upi(upi) do
       nil ->
         {:ok, upi}

--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -15,7 +15,6 @@ defmodule Snitch.Data.Model.Product do
 
   @product_states [:active, :in_active, :draft]
 
-  @callback generate_upn() :: string()
   @doc """
   Returns all Products
   """
@@ -518,20 +517,30 @@ defmodule Snitch.Data.Model.Product do
     Nanoid.generate(10, "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ")
   end
 
-  # TODO: write test case for this
-  def upn_generate() do
-    upn = "A" <> gen_nano_id() <> "C"
+  def generate_upi() do
+    upi = "A" <> gen_nano_id() <> "C"
 
-    case get_product_with_upn(upn) do
-      nil ->
-        upn
+    case upi_generate(upi) do
+      {:error, _} ->
+        generate_upi()
 
-      _ ->
-        upn_generate()
+      {:ok, upi} ->
+        upi
     end
   end
 
-  defp get_product_with_upn(upn) do
-    from(p in "snitch_products", select: p.upn, where: p.upn == ^upn) |> Repo.one()
+  # TODO: write test case for this
+  def upi_generate(upi) do
+    case get_product_with_upi(upi) do
+      nil ->
+        {:ok, upi}
+
+      _ ->
+        {:error, "not_unique"}
+    end
+  end
+
+  defp get_product_with_upi(upi) do
+    from(p in "snitch_products", select: p.upi, where: p.upi == ^upi) |> Repo.one()
   end
 end

--- a/apps/snitch_core/lib/core/data/schema/product.ex
+++ b/apps/snitch_core/lib/core/data/schema/product.ex
@@ -36,10 +36,10 @@ defmodule Snitch.Data.Schema.Product do
     field(:discontinue_on, :utc_datetime)
     field(:slug, :string)
 
-    # unique product number(upn) to indentify a product uniquely
+    # unique product identifier(upi) to indentify a product uniquely
     # just like amazon uses asin (Amazon Standard Identification Number)
     # for unique identification of products.
-    field(:upn, :string, autogenerate: {ProductModel, :upn_generate, []})
+    field(:upi, :string, autogenerate: {ProductModel, :generate_upi, []})
 
     field(:meta_description, :string)
     field(:meta_keywords, :string)
@@ -161,7 +161,7 @@ defmodule Snitch.Data.Schema.Product do
     |> validate_required(@required_fields)
     |> validate_amount(:selling_price)
     |> NameSlug.maybe_generate_slug()
-    |> unique_constraint(:upn, message: "Ooops, another product already has that name!")
+    |> unique_constraint(:upi, message: "Ooops, another product already has that name!")
   end
 
   def product_by_category_query(taxon_id) do

--- a/apps/snitch_core/mix.exs
+++ b/apps/snitch_core/mix.exs
@@ -76,7 +76,6 @@ defmodule Snitch.Core.Mixfile do
       {:ex_doc, "~> 0.16", only: :dev, runtime: false},
       {:excoveralls, "~> 0.8.2", only: :test},
       {:mox, "~> 0.3", only: :test},
-      {:mock, "~> 0.3.0", only: :test},
       {:ex_machina, "~> 2.2", only: :test},
       {:dialyxir, "~> 0.5", only: [:dev], runtime: false},
       {:inch_ex, "~> 0.5.6", only: [:docs, :dev]},

--- a/apps/snitch_core/priv/repo/migrations/20190117065101_add_upi_field_to_products.exs
+++ b/apps/snitch_core/priv/repo/migrations/20190117065101_add_upi_field_to_products.exs
@@ -1,0 +1,12 @@
+defmodule Snitch.Repo.Migrations.AddUpiFieldToProducts do
+  use Ecto.Migration
+
+  def change do
+    alter table("snitch_products") do
+      remove :upn
+      add(:upi, :string)
+    end
+
+    create unique_index("snitch_products", [:upi])
+  end
+end

--- a/apps/snitch_core/test/data/model/product_test.exs
+++ b/apps/snitch_core/test/data/model/product_test.exs
@@ -160,7 +160,7 @@ defmodule Snitch.Data.Model.ProductTest do
 
     test "if no matching upi exists", %{product: product, valid_params: vp} do
       {:ok, %ProductSchema{} = new_product} = Product.create(vp)
-      assert product.upi != new_product.upi
+      refute product.upi == new_product.upi
     end
 
     test "if a product with generated upi exists", %{product: product} do
@@ -170,20 +170,20 @@ defmodule Snitch.Data.Model.ProductTest do
     end
   end
 
-  describe "test upi generate function" do
+  describe "test return upi function" do
     setup do
       product = insert(:product)
       [product: product]
     end
 
-    test "if a upi has already been assigned to a product", %{product: product} do
+    test "if the upi has already been assigned to a product", %{product: product} do
       upi = product.upi
-      assert Product.upi_generate(upi) == {:error, "not_unique"}
+      assert Product.get_upi_if_unique(upi) == {:error, "not_unique"}
     end
 
-    test "if an existing product upi is passed as an argument", %{product: product} do
+    test "if a non existing product upi is passed as an argument", %{product: product} do
       upi = "AMDQMQRZ59OC"
-      assert Product.upi_generate(upi) == {:ok, upi}
+      assert Product.get_upi_if_unique(upi) == {:ok, upi}
     end
   end
 

--- a/apps/snitch_core/test/data/model/product_test.exs
+++ b/apps/snitch_core/test/data/model/product_test.exs
@@ -2,7 +2,6 @@ defmodule Snitch.Data.Model.ProductTest do
   use ExUnit.Case
   use Snitch.DataCase
   import Snitch.Factory
-  import Mock
   alias Snitch.Data.Model.Product
   alias Snitch.Data.Schema.Product, as: ProductSchema
   alias Snitch.Data.Schema.{Variation, Image}
@@ -153,21 +152,38 @@ defmodule Snitch.Data.Model.ProductTest do
     end
   end
 
-  describe "upn generation for a product" do
+  describe "upi generation for a product" do
     setup do
       product = insert(:product)
       [product: product]
     end
 
-    test "if no matching upn exists", %{product: product, valid_params: vp} do
+    test "if no matching upi exists", %{product: product, valid_params: vp} do
       {:ok, %ProductSchema{} = new_product} = Product.create(vp)
-      assert product.upn != new_product.upn
+      assert product.upi != new_product.upi
     end
 
-    test "if a product with generated upn exists", %{product: product} do
+    test "if a product with generated upi exists", %{product: product} do
       assert_raise Ecto.ConstraintError, fn ->
-        insert(:product, %{upn: product.upn})
+        insert(:product, %{upi: product.upi})
       end
+    end
+  end
+
+  describe "test upi generate function" do
+    setup do
+      product = insert(:product)
+      [product: product]
+    end
+
+    test "if a upi has already been assigned to a product", %{product: product} do
+      upi = product.upi
+      assert Product.upi_generate(upi) == {:error, "not_unique"}
+    end
+
+    test "if an existing product upi is passed as an argument", %{product: product} do
+      upi = "AMDQMQRZ59OC"
+      assert Product.upi_generate(upi) == {:ok, upi}
     end
   end
 


### PR DESCRIPTION
## Why?
To test the scenario when a duplicate upi is generated for a product.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
1. Returning success tuple if generated upi is unique and error tuple if it's not a unique one.
2. Rename upn to upi for products.

migration added:

20190117065101_add_upi_field_to_products.exs
<!--- List and detail all changes made in this PR. -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

