### PR TITLE
Format reponse tuples for getter functions.

### DIFF
--- a/apps/admin_app/lib/admin_app/order/order.ex
+++ b/apps/admin_app/lib/admin_app/order/order.ex
@@ -11,8 +11,9 @@ defmodule AdminApp.OrderContext do
   alias Snitch.Data.Model.Payment
 
   def get_order(%{"number" => number}) do
-    %{number: number}
-    |> OrderModel.get()
+    {:ok, order} = OrderModel.get(%{number: number})
+
+    order
     |> Repo.preload([
       [line_items: :product],
       [packages: [:items, :shipping_method]],
@@ -22,9 +23,9 @@ defmodule AdminApp.OrderContext do
   end
 
   def get_order(%{"id" => id}) do
-    id
-    |> String.to_integer()
-    |> OrderModel.get()
+    {:ok, order} = id |> String.to_integer() |> OrderModel.get()
+
+    order
     |> Repo.preload([
       [line_items: :product],
       [packages: [:items, :shipping_method]],

--- a/apps/admin_app/lib/admin_app_web/controllers/api/stock_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/api/stock_controller.ex
@@ -12,7 +12,7 @@ defmodule AdminAppWeb.Api.StockController do
   end
 
   def update_stock(conn, params) do
-    with %Product{} = product <- ProductModel.get(params["stock"]["product_id"]),
+    with {:ok, %Product{} = product} <- ProductModel.get(params["stock"]["product_id"]),
          {:ok, stock} <- Inventory.add_stock(product, params["stock"]) do
       render(conn, "stocks.json", %{stocks: [stock]})
     else

--- a/apps/admin_app/lib/admin_app_web/controllers/general_settings_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/general_settings_controller.ex
@@ -38,13 +38,14 @@ defmodule AdminAppWeb.GeneralSettingsController do
   end
 
   def edit(conn, %{"id" => id}) do
-    general_configuration = GCModel.get_general_configuration(id) |> Repo.preload(:image)
+    general_configuration = GCModel.get_general_configuration(id)
 
     case general_configuration do
-      nil ->
+      {:error, _} ->
         handle_nil_response(conn)
 
-      _ ->
+      {:ok, general_config} ->
+        general_configuration = general_config |> Repo.preload(:image)
         changeset = GCSchema.update_changeset(general_configuration, %{})
 
         render(
@@ -59,14 +60,14 @@ defmodule AdminAppWeb.GeneralSettingsController do
   def update(conn, %{"id" => id, "settings" => params}) do
     params = handle_params(params)
     params = %{params | "image" => Image.handle_image_value(params["image"])}
-    general_configuration = GCModel.get_general_configuration(id) |> Repo.preload(:image)
 
-    case general_configuration do
-      nil ->
+    case GCModel.get_general_configuration(id) do
+      {:error, _} ->
         handle_nil_response(conn)
 
-      _ ->
+      {:ok, general_configuration} ->
         params
+        general_configuration = general_configuration |> Repo.preload(:image)
 
         case GCModel.update(general_configuration, params) do
           {:ok, general_configuration} ->

--- a/apps/admin_app/lib/admin_app_web/controllers/option_type_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/option_type_controller.ex
@@ -26,7 +26,7 @@ defmodule AdminAppWeb.OptionTypeController do
 
   def edit(conn, %{"id" => id}) do
     with {id, _} <- Integer.parse(id),
-         %OTSchema{} = option_type <- OTModel.get(id) do
+         {:ok, %OTSchema{} = option_type} <- OTModel.get(id) do
       changeset = OTSchema.update_changeset(option_type, %{})
       render(conn, "edit.html", changeset: changeset)
     else
@@ -39,7 +39,7 @@ defmodule AdminAppWeb.OptionTypeController do
 
   def update(conn, %{"id" => id, "option_type" => params}) do
     with {id, _} <- Integer.parse(id),
-         option_type <- OTModel.get(id),
+         {:ok, option_type} <- OTModel.get(id),
          {:ok, _} <- OTModel.update(option_type, params) do
       option_types = OTModel.get_all()
       render(conn, "index.html", %{option_types: option_types})

--- a/apps/admin_app/lib/admin_app_web/controllers/order_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/order_controller.ex
@@ -326,8 +326,9 @@ defmodule AdminAppWeb.OrderController do
   end
 
   defp load_order(order) do
+    {:ok, order} = order |> Order.get()
+
     order
-    |> Order.get()
     |> Repo.preload([
       [line_items: :product],
       [packages: [:items, :shipping_method]],

--- a/apps/admin_app/lib/admin_app_web/controllers/payment_method_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/payment_method_controller.ex
@@ -52,12 +52,12 @@ defmodule AdminAppWeb.PaymentMethodController do
     payment = PaymentMethod.get(String.to_integer(id))
 
     case payment do
-      nil ->
+      {:error, msg} ->
         conn
         |> put_flash(:error, "Sorry method not found")
         |> redirect(to: payment_method_path(conn, :index))
 
-      payment_method ->
+      {:ok, payment_method} ->
         changeset = PaymentMethodSchema.update_changeset(payment_method, %{})
         render(conn, "edit.html", changeset: changeset, payment_method: payment_method)
     end
@@ -65,7 +65,7 @@ defmodule AdminAppWeb.PaymentMethodController do
 
   def update(conn, %{"id" => id, "payment_method" => params}) do
     update_params = handle_payment_code(params)
-    payment_method = PaymentMethod.get(String.to_integer(id))
+    {:ok, payment_method} = PaymentMethod.get(String.to_integer(id))
 
     case PaymentMethod.update(update_params, payment_method) do
       {:ok, _} ->

--- a/apps/admin_app/lib/admin_app_web/controllers/permission_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/permission_controller.ex
@@ -32,12 +32,12 @@ defmodule AdminAppWeb.PermissionController do
 
   def edit(conn, %{"id" => id}) do
     case Permission.get(String.to_integer(id)) do
-      nil ->
+      {:error, msg} ->
         conn
         |> put_flash(:error, "Sorry not found")
         |> redirect(to: permission_path(conn, :index))
 
-      permission ->
+      {:ok, permission} ->
         changeset = PermissionSchema.update_changeset(permission, %{})
         render(conn, "edit.html", changeset: changeset, permission: permission)
     end
@@ -46,7 +46,7 @@ defmodule AdminAppWeb.PermissionController do
   def update(conn, %{"id" => id, "permission" => permission}) do
     id = String.to_integer(id)
     params = parse_permission_params(permission)
-    permission = Permission.get(id)
+    {:ok, permission} = Permission.get(id)
 
     case Permission.update(params, permission) do
       {:ok, _} ->

--- a/apps/admin_app/lib/admin_app_web/controllers/product_brand_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/product_brand_controller.ex
@@ -33,11 +33,12 @@ defmodule AdminAppWeb.ProductBrandController do
   end
 
   def edit(conn, %{"id" => id}) do
-    with %ProductBrandSchema{} = brand <- id |> ProductBrandModel.get() |> Repo.preload(:image),
+    with {:ok, %ProductBrandSchema{} = brand_struct} <- id |> ProductBrandModel.get(),
+         brand <- brand_struct |> Repo.preload(:image),
          changeset <- ProductBrandSchema.update_changeset(brand, %{}) do
       render(conn, "edit.html", changeset: changeset, brand: brand)
     else
-      nil ->
+      {:error, _} ->
         conn
         |> put_flash(:info, "Product Brand not found")
         |> redirect(to: product_brand_path(conn, :index))
@@ -47,7 +48,8 @@ defmodule AdminAppWeb.ProductBrandController do
   def update(conn, %{"id" => id, "product_brand" => params}) do
     params = handle_params(params)
 
-    with %ProductBrandSchema{} = brand <- id |> ProductBrandModel.get() |> Repo.preload(:image),
+    with {:ok, %ProductBrandSchema{} = brand_struct} <- id |> ProductBrandModel.get(),
+         brand <- brand_struct |> Repo.preload(:image),
          {:ok, _} <- ProductBrandModel.update(brand, params) do
       conn
       |> put_flash(:info, "Product Brand update successfully")

--- a/apps/admin_app/lib/admin_app_web/controllers/promotion_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/promotion_controller.ex
@@ -14,7 +14,7 @@ defmodule AdminAppWeb.PromotionController do
 
   def create(conn, %{"data" => data}) do
     with {:ok, promotion} <- Promotion.create(data) do
-      promotion = Promotion.get(%{id: promotion.id})
+      {:ok, promotion} = Promotion.get(%{id: promotion.id})
       render(conn, "promotion.json", promotion: promotion)
     else
       {:error, changeset} ->
@@ -27,9 +27,9 @@ defmodule AdminAppWeb.PromotionController do
   def update(conn, %{"data" => data, "id" => id}) do
     id = String.to_integer(id)
 
-    with promotion when not is_nil(promotion) <- Promotion.get(%{id: id}),
+    with {:ok, promotion} <- Promotion.get(%{id: id}),
          {:ok, promotion} <- Promotion.update(promotion, data) do
-      promotion = Promotion.get(%{id: promotion.id})
+      {:ok, promotion} = Promotion.get(%{id: promotion.id})
       render(conn, "promotion.json", promotion: promotion)
     else
       {:error, %Ecto.Changeset{} = changeset} ->
@@ -42,20 +42,20 @@ defmodule AdminAppWeb.PromotionController do
         |> put_status(422)
         |> render("error_message.json", message: message)
 
-      nil ->
-        conn
-        |> put_status(401)
-        |> render(AdminAppWeb.ErrorView, "401.json")
+        # nil ->
+        #   conn
+        #   |> put_status(401)
+        #   |> render(AdminAppWeb.ErrorView, "401.json")
     end
   end
 
   def edit(conn, %{"id" => id}) do
     id = String.to_integer(id)
 
-    with promotion when not is_nil(promotion) <- Promotion.get(%{id: id}) do
+    with {:ok, promotion} <- Promotion.get(%{id: id}) do
       render(conn, "promotion.json", promotion: promotion)
     else
-      nil ->
+      {:error, _} ->
         conn
         |> put_status(401)
         |> render(AdminAppWeb.ErrorView, "401.json")
@@ -65,11 +65,11 @@ defmodule AdminAppWeb.PromotionController do
   def archive(conn, %{"id" => id}) do
     id = String.to_integer(id)
 
-    with promotion when not is_nil(promotion) <- Promotion.get(%{id: id}),
+    with {:ok, promotion} <- Promotion.get(%{id: id}),
          {:ok, _promotion} <- Promotion.archive(promotion) do
       conn |> put_status(200) |> json(%{message: "promotion archived"})
     else
-      nil ->
+      {:error, _} ->
         conn
         |> put_status(401)
         |> render(AdminAppWeb.ErrorView, "401.json")

--- a/apps/admin_app/lib/admin_app_web/controllers/property_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/property_controller.ex
@@ -27,7 +27,7 @@ defmodule AdminAppWeb.PropertyController do
 
   def edit(conn, %{"id" => id}) do
     with {id, _} <- Integer.parse(id),
-         %PropertySchema{} = property <- PropertyModel.get(id) do
+         {:ok, %PropertySchema{} = property} <- PropertyModel.get(id) do
       changeset = PropertySchema.update_changeset(property, %{})
       render(conn, "edit.html", changeset: changeset)
     else
@@ -40,7 +40,7 @@ defmodule AdminAppWeb.PropertyController do
 
   def update(conn, %{"id" => id, "property" => params}) do
     with {id, _} <- Integer.parse(id),
-         property <- PropertyModel.get(id),
+         {:ok, property} <- PropertyModel.get(id),
          {:ok, _} <- PropertyModel.update(property, params) do
       properties = PropertyModel.get_all()
       render(conn, "index.html", %{properties: properties})

--- a/apps/admin_app/lib/admin_app_web/controllers/prototype_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/prototype_controller.ex
@@ -31,11 +31,11 @@ defmodule AdminAppWeb.PrototypeController do
 
   def edit(conn, %{"id" => id}) do
     case PrototypeModel.get(id) do
-      %PrototypeSchema{} = prototype ->
+      {:ok, %PrototypeSchema{} = prototype} ->
         changeset = PrototypeSchema.update_changeset(prototype, %{})
         render(conn, "edit.html", changeset: changeset)
 
-      nil ->
+      {:error, _} ->
         conn
         |> put_flash(:info, "Prototype not found")
         |> redirect(to: prototype_path(conn, :index))
@@ -43,7 +43,7 @@ defmodule AdminAppWeb.PrototypeController do
   end
 
   def update(conn, %{"id" => id, "product_prototype" => params}) do
-    with %PrototypeSchema{} = prototype <- PrototypeModel.get(id),
+    with {:ok, %PrototypeSchema{} = prototype} <- PrototypeModel.get(id),
          {:ok, _} <- PrototypeModel.update(prototype, params) do
       prototypes = PrototypeModel.get_all()
       render(conn, "index.html", prototypes: prototypes)

--- a/apps/admin_app/lib/admin_app_web/controllers/role_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/role_controller.ex
@@ -38,15 +38,15 @@ defmodule AdminAppWeb.RoleController do
       id
       |> String.to_integer()
       |> Role.get()
-      |> Repo.preload(:permissions)
 
     case role do
-      nil ->
+      {:error, _} ->
         conn
         |> put_flash(:error, "Sorry role not found")
         |> redirect(to: role_path(conn, :index))
 
-      role ->
+      {:ok, role} ->
+        role = role |> Repo.preload(:permissions)
         changeset = RoleSchema.update_changeset(role, %{})
         render(conn, "edit.html", changeset: changeset, role: role)
     end
@@ -56,10 +56,8 @@ defmodule AdminAppWeb.RoleController do
     id = String.to_integer(id)
     params = parse_role_params(role)
 
-    role =
-      id
-      |> Role.get()
-      |> Repo.preload(:permissions)
+    {:ok, role} = Role.get(id)
+    role = role |> Repo.preload(:permissions)
 
     case Role.update(params, role) do
       {:ok, _} ->

--- a/apps/admin_app/lib/admin_app_web/controllers/session_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/session_controller.ex
@@ -32,7 +32,7 @@ defmodule AdminAppWeb.SessionController do
   end
 
   def update(conn, %{"id" => id, "new_password" => password_params}) do
-    user = UserModel.get(%{id: id})
+    {:ok, user} = UserModel.get(%{id: id})
     update_user = UserModel.update(password_params, user)
     update_password_result(update_user, conn)
   end
@@ -49,7 +49,7 @@ defmodule AdminAppWeb.SessionController do
 
   def check_email(conn, %{"password_reset" => params}) do
     email = params["email"]
-    user = UserModel.get(%{email: email})
+    {:ok, user} = UserModel.get(%{email: email})
     mail_verified_user(user, conn)
   end
 

--- a/apps/admin_app/lib/admin_app_web/controllers/shipping_policy_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/shipping_policy_controller.ex
@@ -14,7 +14,7 @@ defmodule AdminAppWeb.ShippingPolicyController do
       |> Repo.all()
       |> List.first()
 
-    shipping_category = ScModel.get_with_rules(shipping_category.id)
+    {:ok, shipping_category} = ScModel.get_with_rules(shipping_category.id)
 
     render(conn, "index.html",
       shipping_rules: shipping_category.shipping_rules,
@@ -24,12 +24,12 @@ defmodule AdminAppWeb.ShippingPolicyController do
 
   def edit(conn, %{"id" => id}) do
     case ScModel.get_with_rules(id) do
-      nil ->
+      {:error, _} ->
         conn
         |> put_flash(:error, "Not found")
         |> redirect(to: shipping_policy_path(conn, :new))
 
-      category ->
+      {:ok, category} ->
         render(conn, "edit.html",
           shipping_rules: category.shipping_rules,
           shipping_category: category
@@ -39,7 +39,7 @@ defmodule AdminAppWeb.ShippingPolicyController do
 
   def update(conn, %{"id" => id, "shipping_policy" => shipping_policy}) do
     update_params = shipping_category_params(id, shipping_policy)
-    category = ScModel.get_with_rules(update_params.id)
+    {:ok, category} = ScModel.get_with_rules(update_params.id)
 
     case ScModel.update(update_params, category) do
       {:ok, category} ->

--- a/apps/admin_app/lib/admin_app_web/controllers/stock_location_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/stock_location_controller.ex
@@ -15,8 +15,7 @@ defmodule AdminAppWeb.StockLocationController do
 
   def show(conn, %{"id" => id}) do
     with {id, _} <- Integer.parse(id),
-         stock_location <- SLModel.get(id),
-         false <- is_nil(stock_location) do
+         {:ok, stock_location} <- SLModel.get(id) do
       render(conn, "show.html", stock_location: stock_location)
     else
       _ ->
@@ -73,8 +72,7 @@ defmodule AdminAppWeb.StockLocationController do
 
   def edit(conn, %{"id" => id}) do
     with {id, _} <- Integer.parse(id),
-         stock_location <- SLModel.get(id),
-         false <- is_nil(stock_location) do
+         {:ok, stock_location} <- SLModel.get(id) do
       changeset = SLSchema.update_changeset(stock_location, %{})
       render(conn, "edit.html", changeset: changeset, stock_location: stock_location)
     else
@@ -87,7 +85,7 @@ defmodule AdminAppWeb.StockLocationController do
 
   def update(conn, %{"id" => id, "stock_location" => stock_location_params}) do
     {id, _} = Integer.parse(id)
-    stock_location = SLModel.get(id)
+    {:ok, stock_location} = SLModel.get(id)
 
     with {:ok, _} <- SLModel.update(stock_location_params, stock_location) do
       conn

--- a/apps/admin_app/lib/admin_app_web/controllers/template_api/option_type_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/template_api/option_type_controller.ex
@@ -7,9 +7,8 @@ defmodule AdminAppWeb.TemplateApi.OptionTypeController do
   import Phoenix.View, only: [render_to_string: 3]
 
   def index(conn, %{"theme_id" => theme_id} = params) do
-    theme =
-      VariationTheme.get(theme_id)
-      |> Repo.preload(:option_types)
+    {:ok, theme} = VariationTheme.get(theme_id)
+    theme = theme |> Repo.preload(:option_types)
 
     product_id = params["product_id"]
 
@@ -21,7 +20,7 @@ defmodule AdminAppWeb.TemplateApi.OptionTypeController do
   end
 
   def update(conn, %{"id" => id} = params) do
-    with option_value <- ProductOptionValue.get(id),
+    with {:ok, option_value} <- ProductOptionValue.get(id),
          {:ok, option_value} <- ProductOptionValue.update(option_value, params) do
       render(conn, "option_value.json", option_value: option_value)
     end

--- a/apps/admin_app/lib/admin_app_web/controllers/user_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/user_controller.ex
@@ -33,12 +33,12 @@ defmodule AdminAppWeb.UserController do
 
   def edit(conn, %{"id" => id}) do
     case UserModel.get(String.to_integer(id)) do
-      nil ->
+      {:error, _} ->
         conn
         |> put_flash(:error, "Sorry user not found")
         |> render("index.html")
 
-      user ->
+      {:ok, user} ->
         changeset = User.update_changeset(user, %{})
         render(conn, "edit.html", changeset: changeset, user: user)
     end
@@ -48,10 +48,8 @@ defmodule AdminAppWeb.UserController do
     id = String.to_integer(id)
     params = parse_user_params(user)
 
-    user =
-      id
-      |> UserModel.get()
-      |> Repo.preload(:role)
+    {:ok, user} = UserModel.get(id)
+    user = user |> Repo.preload(:role)
 
     case UserModel.update(params, user) do
       {:ok, _} ->

--- a/apps/admin_app/lib/admin_app_web/controllers/variation_theme_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/variation_theme_controller.ex
@@ -30,11 +30,11 @@ defmodule AdminAppWeb.VariationThemeController do
 
   def edit(conn, %{"id" => id}) do
     case VTModel.get(id) do
-      %VTSchema{} = theme ->
+      {:ok, %VTSchema{} = theme} ->
         changeset = VTSchema.update_changeset(theme, %{})
         render(conn, "edit.html", changeset: changeset)
 
-      nil ->
+      {:error, _} ->
         conn
         |> put_flash(:info, "Variation theme not found")
         |> redirect(to: variation_theme_path(conn, :index))
@@ -42,18 +42,18 @@ defmodule AdminAppWeb.VariationThemeController do
   end
 
   def update(conn, %{"id" => id, "variation_theme" => params}) do
-    with %VTSchema{} = theme <- VTModel.get(id),
+    with {:ok, %VTSchema{} = theme} <- VTModel.get(id),
          {:ok, _} <- VTModel.update(theme, params) do
       themes = VTModel.get_all()
       render(conn, "index.html", themes: themes)
     else
-      {:error, changeset} ->
-        render(conn, "edit.html", changeset: %{changeset | action: :edit})
-
-      nil ->
+      {:error, :variation_theme_not_found} ->
         conn
         |> put_flash(:info, "Variation theme not found")
         |> redirect(to: variation_theme_path(conn, :index))
+
+      {:error, changeset} ->
+        render(conn, "edit.html", changeset: %{changeset | action: :edit})
     end
   end
 

--- a/apps/admin_app/lib/admin_app_web/controllers/zone_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/zone_controller.ex
@@ -62,15 +62,15 @@ defmodule AdminAppWeb.ZoneController do
       |> put_flash(:info, "Zone updated!!")
       |> redirect(to: zone_path(conn, :index))
     else
-      {:error, _, changeset, _} ->
-        conn
-        |> put_flash(:error, "Sorry there were some errors !!")
-        |> render("edit.html", changeset: changeset, id: params["id"])
-
       nil ->
         conn
         |> put_flash(:info, "Zone not found")
         |> redirect(to: zone_path(conn, :index))
+
+      {:error, _, changeset, _} ->
+        conn
+        |> put_flash(:error, "Sorry there were some errors !!")
+        |> render("edit.html", changeset: changeset, id: params["id"])
     end
   end
 

--- a/apps/admin_app/lib/admin_app_web/guardian.ex
+++ b/apps/admin_app/lib/admin_app_web/guardian.ex
@@ -27,13 +27,13 @@ defmodule AdminAppWeb.Guardian do
       user_id
       |> String.to_integer()
       |> User.get()
-      |> Repo.preload(role: [:permissions])
 
     case current_user do
-      nil ->
+      {:error, _} ->
         {:error, "user not found"}
 
-      user ->
+      {:ok, user} ->
+        user = user |> Repo.preload(role: [:permissions])
         {:ok, user}
     end
   end

--- a/apps/admin_app/lib/admin_app_web/views/order_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/order_view.ex
@@ -247,11 +247,15 @@ defmodule AdminAppWeb.OrderView do
   end
 
   def get_country(country_id) do
-    Country.get(country_id)
+    Country.get(country_id) |> get_response
   end
 
   def get_state(state_id) do
-    State.get(state_id)
+    State.get(state_id) |> get_response
+  end
+
+  defp get_response({:ok, struct}) do
+    struct
   end
 
   defp get_state_name(state_id) do

--- a/apps/snitch_api/lib/snitch_api/payment/cod_payment.ex
+++ b/apps/snitch_api/lib/snitch_api/payment/cod_payment.ex
@@ -5,13 +5,13 @@ defmodule SnitchApi.CodPayment do
   alias Snitch.Core.Tools.MultiTenancy.Repo
 
   def make_payment(order_id) do
-    with order when not is_nil(order) <- Order.get(order_id) do
+    with {:ok, order} <- Order.get(order_id) do
       context = Context.new(order)
       transition = DefaultMachine.confirm_cod_payment(context)
       transition_response(transition)
     else
-      _ ->
-        {:error, :not_found}
+      {:error, msg} ->
+        {:error, msg}
     end
   end
 

--- a/apps/snitch_api/lib/snitch_api/review.ex
+++ b/apps/snitch_api/lib/snitch_api/review.ex
@@ -12,10 +12,10 @@ defmodule SnitchApi.Review do
     %{"rating_option_id" => option_id} = params
 
     case Rating.get_rating_option(option_id) do
-      nil ->
+      {:error, _} ->
         {:error, %{message: "rating_option_not_found"}}
 
-      rating_option ->
+      {:ok, rating_option} ->
         params = product_review_params(attributes, product_id, rating_option)
         ProductReview.add(params)
     end
@@ -25,10 +25,10 @@ defmodule SnitchApi.Review do
     attributes = parse_attribute_params(params)
 
     case Rating.get_rating_option(rating_option_id) do
-      nil ->
+      {:error, _} ->
         {:error, %{message: "rating_option_not_found"}}
 
-      rating_option ->
+      {:ok, rating_option} ->
         params = Map.put(attributes, :rating_option_vote, %{rating_option: rating_option})
         update_review(id, params)
     end

--- a/apps/snitch_api/lib/snitch_api_web/controllers/address_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/address_controller.ex
@@ -72,12 +72,12 @@ defmodule SnitchApiWeb.AddressController do
 
   def country_states(conn, %{"id" => country_id}) do
     case Country.get(country_id) do
-      nil ->
+      {:error, msg} ->
         conn
-        |> put_status(:not_found)
+        |> put_status(msg)
         |> render(SnitchApiWeb.ErrorView, :"404")
 
-      country ->
+      {:ok, country} ->
         country_with_states = Repo.preload(country, :states)
 
         render(

--- a/apps/snitch_api/lib/snitch_api_web/controllers/line_item_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/line_item_controller.ex
@@ -102,12 +102,12 @@ defmodule SnitchApiWeb.LineItemController do
 
   def show(conn, %{"id" => id}) do
     case LineItemModel.get(id) do
-      nil ->
+      {:error, :line_item_not_found} ->
         conn
         |> put_status(204)
         |> render("show.json-api", data: [])
 
-      line_item ->
+      {:ok, line_item} ->
         conn
         |> put_status(200)
         |> render("show.json-api", data: line_item)

--- a/apps/snitch_api/lib/snitch_api_web/controllers/order_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/order_controller.ex
@@ -73,7 +73,7 @@ defmodule SnitchApiWeb.OrderController do
   end
 
   def fetch_guest_order(conn, %{"order_number" => order_number}) do
-    with %Order{} = order <- OrderModel.get(%{number: order_number}) do
+    with {:ok, %Order{} = order} <- OrderModel.get(%{number: order_number}) do
       line_item_query =
         from(
           LineItem,
@@ -95,7 +95,7 @@ defmodule SnitchApiWeb.OrderController do
         ]
       )
     else
-      nil ->
+      {:error, _} ->
         conn
         |> put_status(200)
         |> render("empty.json-api", data: %{})

--- a/apps/snitch_api/lib/snitch_api_web/controllers/product_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/product_controller.ex
@@ -12,7 +12,7 @@ defmodule SnitchApiWeb.ProductController do
   action_fallback(SnitchApiWeb.FallbackController)
 
   def reviews(conn, %{"id" => id}) do
-    with product when not is_nil(product) <- Product.get(id) do
+    with {:ok, product} <- Product.get(id) do
       reviews =
         product
         |> Repo.preload(reviews: [rating_option_vote: :rating_option])
@@ -30,7 +30,7 @@ defmodule SnitchApiWeb.ProductController do
   def rating_summary(conn, %{"id" => id}) do
     id = String.to_integer(id)
 
-    with product when not is_nil(product) <- Product.get(id) do
+    with {:ok, product} <- Product.get(id) do
       rating_data = ProductReview.review_aggregate(product)
       render(conn, "rating_summary.json-api", data: rating_data, id: id)
     end

--- a/apps/snitch_api/lib/snitch_api_web/controllers/promotion_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/promotion_controller.ex
@@ -2,16 +2,14 @@ defmodule SnitchApiWeb.PromotionController do
   use SnitchApiWeb, :controller
 
   alias Snitch.Data.Model.Order
+  alias Snitch.Data.Schema.Order, as: OrderSchema
   alias Snitch.Data.Model.Promotion
 
   def apply(conn, %{"order_number" => order_number, "promo_code" => promo_code}) do
-    with order when not is_nil(order) <- Order.get(%{number: order_number}),
+    with {:ok, %OrderSchema{} = order} <- Order.get(%{number: order_number}),
          {:ok, message} <- Promotion.apply(order, promo_code) do
       render(conn, "success.json-api", %{message: message})
     else
-      nil ->
-        render(conn, "error.json-api", %{message: "order not found"})
-
       {:error, message} ->
         render(conn, "error.json-api", %{message: message})
     end

--- a/apps/snitch_api/lib/snitch_api_web/controllers/rating_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/rating_controller.ex
@@ -12,11 +12,8 @@ defmodule SnitchApiWeb.RatingController do
   end
 
   def show(conn, %{"id" => rating_id}) do
-    rating =
-      rating_id
-      |> String.to_integer()
-      |> Rating.get()
-      |> Repo.preload(:rating_options)
+    {:ok, rating} =  rating_id |> String.to_integer() |> Rating.get()
+    rating = rating |> Repo.preload(:rating_options)
 
     render(
       conn,

--- a/apps/snitch_api/lib/snitch_api_web/controllers/rating_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/rating_controller.ex
@@ -12,7 +12,7 @@ defmodule SnitchApiWeb.RatingController do
   end
 
   def show(conn, %{"id" => rating_id}) do
-    {:ok, rating} =  rating_id |> String.to_integer() |> Rating.get()
+    {:ok, rating} = rating_id |> String.to_integer() |> Rating.get()
     rating = rating |> Repo.preload(:rating_options)
 
     render(

--- a/apps/snitch_api/lib/snitch_api_web/controllers/user_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/user_controller.ex
@@ -29,7 +29,7 @@ defmodule SnitchApiWeb.UserController do
   def login(conn, %{"email" => email, "password" => password}) do
     case Accounts.token_sign_in(email, password) do
       {:ok, token, _claims} ->
-        user = UserModel.get(%{email: email})
+        {:ok, user} = UserModel.get(%{email: email})
         render(conn, "token.json-api", data: token, user: user)
 
       _ ->

--- a/apps/snitch_api/lib/snitch_api_web/views/address_view.ex
+++ b/apps/snitch_api/lib/snitch_api_web/views/address_view.ex
@@ -23,13 +23,13 @@ defmodule SnitchApiWeb.AddressView do
   ])
 
   def country(address, _conn) do
-    Country.get(address.country_id)
-    |> Map.take([:name, :iso_name])
+    {:ok, country} = Country.get(address.country_id)
+    country |> Map.take([:name, :iso_name])
   end
 
   def state(address, _conn) do
-    State.get(address.state_id)
-    |> Map.take([:name, :code])
+    {:ok, state} = State.get(address.state_id)
+    state |> Map.take([:name, :code])
   end
 
   def render("address.json-api", %{data: address}) do

--- a/apps/snitch_core/lib/core/data/model/country.ex
+++ b/apps/snitch_core/lib/core/data/model/country.ex
@@ -7,7 +7,7 @@ defmodule Snitch.Data.Model.Country do
 
   alias Snitch.Data.Schema.Country
 
-  @spec get(map | non_neg_integer) :: Country.t() | nil
+  @spec get(map | non_neg_integer) :: {:ok, Country.t()} | {:error, atom}
   def get(query_fields_or_primary_key) do
     QH.get(Country, query_fields_or_primary_key, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/general_configuration.ex
+++ b/apps/snitch_core/lib/core/data/model/general_configuration.ex
@@ -31,7 +31,7 @@ defmodule Snitch.Data.Model.GeneralConfiguration do
     %GC{} |> GC.create_changeset(attrs)
   end
 
-  @spec get_general_configuration(integer) :: GC.t() | nil
+  @spec get_general_configuration(integer) :: {:ok, GC.t()} | {:error, atom}
   def get_general_configuration(id) do
     QH.get(GC, id, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/line_item.ex
+++ b/apps/snitch_core/lib/core/data/model/line_item.ex
@@ -61,7 +61,7 @@ defmodule Snitch.Data.Model.LineItem do
     |> Repo.delete()
   end
 
-  @spec get(map) :: LineItem.t() | nil
+  @spec get(map) :: {:ok, LineItem.t()} | {:error, atom}
   def get(query_fields) do
     QH.get(LineItem, query_fields, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/option_type.ex
+++ b/apps/snitch_core/lib/core/data/model/option_type.ex
@@ -26,7 +26,7 @@ defmodule Snitch.Data.Model.OptionType do
 
   Takes OptionType id as input
   """
-  @spec get(integer) :: OptionType.t() | nil
+  @spec get(integer) :: {:ok, OptionType.t()} | {:error, atom}
   def get(id) do
     QH.get(OptionType, id, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/order.ex
+++ b/apps/snitch_core/lib/core/data/model/order.ex
@@ -192,7 +192,7 @@ defmodule Snitch.Data.Model.Order do
     QH.delete(Order, id_or_instance, Repo)
   end
 
-  @spec get(map | non_neg_integer) :: Order.t() | nil
+  @spec get(map | non_neg_integer) :: {:ok, Order.t()} | {:error, atom}
   def get(query_fields_or_primary_key) do
     QH.get(Order, query_fields_or_primary_key, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/package.ex
+++ b/apps/snitch_core/lib/core/data/model/package.ex
@@ -31,7 +31,7 @@ defmodule Snitch.Data.Model.Package do
     QH.update(Package, params, package, Repo)
   end
 
-  @spec get(non_neg_integer | map) :: Package.t()
+  @spec get(non_neg_integer | map) :: {:ok, Package.t()} | {:error, atom}
   def get(query_fields) do
     QH.get(Package, query_fields, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/package_item.ex
+++ b/apps/snitch_core/lib/core/data/model/package_item.ex
@@ -33,7 +33,7 @@ defmodule Snitch.Data.Model.PackageItem do
     QH.delete(PackageItem, package_item, Repo)
   end
 
-  @spec get(non_neg_integer | map) :: PackageItem.t()
+  @spec get(non_neg_integer | map) :: {:ok, PackageItem.t()} | {:error, atom}
   def get(query_fields) do
     QH.get(PackageItem, query_fields, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/payment/card_payment.ex
+++ b/apps/snitch_core/lib/core/data/model/payment/card_payment.ex
@@ -81,7 +81,7 @@ defmodule Snitch.Data.Model.CardPayment do
   @doc """
   Fetches the struct but does not preload `:payment` association.
   """
-  @spec get(map | non_neg_integer) :: CardPayment.t() | nil
+  @spec get(map | non_neg_integer) :: {:ok, CardPayment.t()} | {:error, atom}
   def get(query_fields_or_primary_key) do
     QH.get(CardPayment, query_fields_or_primary_key, Repo)
   end
@@ -96,6 +96,7 @@ defmodule Snitch.Data.Model.CardPayment do
   """
   @spec from_payment(non_neg_integer) :: CardPayment.t()
   def from_payment(payment_id) do
-    get(%{payment_id: payment_id})
+    {:ok, payment} = get(%{payment_id: payment_id})
+    payment
   end
 end

--- a/apps/snitch_core/lib/core/data/model/payment/hosted_payment.ex
+++ b/apps/snitch_core/lib/core/data/model/payment/hosted_payment.ex
@@ -31,7 +31,7 @@ defmodule Snitch.Data.Model.HostedPayment do
           | {:error, Ecto.Changeset.t()}
   def create(slug, order_id, payment_params, hosted_method_params, payment_method_id) do
     payment = struct(Payment, payment_params)
-    hosted_method = PaymentMethodModel.get(payment_method_id)
+    {:ok, hosted_method} = PaymentMethodModel.get(payment_method_id)
 
     more_payment_params = %{
       order_id: order_id,
@@ -94,7 +94,7 @@ defmodule Snitch.Data.Model.HostedPayment do
   @doc """
   Fetches the struct but does not preload `:payment` association.
   """
-  @spec get(map | non_neg_integer) :: HostedPayment.t() | nil
+  @spec get(map | non_neg_integer) :: {:ok, HostedPayment.t()} | {:error, atom}
   def get(query_fields_or_primary_key) do
     QH.get(HostedPayment, query_fields_or_primary_key, Repo)
   end
@@ -109,6 +109,7 @@ defmodule Snitch.Data.Model.HostedPayment do
   """
   @spec from_payment(non_neg_integer) :: HostedPayment.t()
   def from_payment(payment_id) do
-    get(%{payment_id: payment_id})
+    {:ok, hosted_payment} = get(%{payment_id: payment_id})
+    hosted_payment
   end
 end

--- a/apps/snitch_core/lib/core/data/model/payment/payment.ex
+++ b/apps/snitch_core/lib/core/data/model/payment/payment.ex
@@ -27,7 +27,7 @@ defmodule Snitch.Data.Model.Payment do
     QH.update(Payment, params, id_or_instance, Repo)
   end
 
-  @spec get(map | non_neg_integer) :: Payment.t() | nil
+  @spec get(map | non_neg_integer) :: {:ok, Payment.t()} | {:error, atom}
   def get(query_fields_or_primary_key) do
     QH.get(Payment, query_fields_or_primary_key, Repo)
   end
@@ -52,8 +52,9 @@ defmodule Snitch.Data.Model.Payment do
   def to_subtype(id_or_instance)
 
   def to_subtype(payment_id) when is_integer(payment_id) do
-    %{id: payment_id}
-    |> get()
+    {:ok, payment} = get(%{id: payment_id})
+
+    payment
     |> to_subtype()
   end
 

--- a/apps/snitch_core/lib/core/data/model/payment/payment_method.ex
+++ b/apps/snitch_core/lib/core/data/model/payment/payment_method.ex
@@ -39,19 +39,31 @@ defmodule Snitch.Data.Model.PaymentMethod do
     QH.delete(PaymentMethod, id_or_instance, Repo)
   end
 
-  @spec get(map | non_neg_integer) :: PaymentMethod.t() | nil
+  @spec get(map | non_neg_integer) :: {:ok, PaymentMethod.t()} | {:error, atom}
   def get(query_fields_or_primary_key) do
     QH.get(PaymentMethod, query_fields_or_primary_key, Repo)
   end
 
   @spec get_card() :: PaymentMethod.t() | nil
   def get_card do
-    get(%{code: "ccd"})
+    case get(%{code: "ccd"}) do
+      {:ok, card} ->
+        card
+
+      {:error, _} ->
+        nil
+    end
   end
 
   @spec get_check() :: PaymentMethod.t() | nil
   def get_check do
-    get(%{code: "chk"})
+    case get(%{code: "chk"}) do
+      {:ok, check} ->
+        check
+
+      {:error, _} ->
+        nil
+    end
   end
 
   @spec get_all() :: [PaymentMethod.t()]

--- a/apps/snitch_core/lib/core/data/model/permission.ex
+++ b/apps/snitch_core/lib/core/data/model/permission.ex
@@ -40,10 +40,10 @@ defmodule Snitch.Data.Model.Permission do
           | {:error, :not_found}
   def delete(id) do
     case QH.get(Permission, id, Repo) do
-      nil ->
-        {:error, :not_found}
+      {:error, msg} ->
+        {:error, msg}
 
-      permission ->
+      {:ok, permission} ->
         permission
         |> Permission.changeset()
         |> Repo.delete()
@@ -55,7 +55,7 @@ defmodule Snitch.Data.Model.Permission do
 
   Takes as input `id` of the Permission  to be retrieved.
   """
-  @spec get(integer) :: Permission.t() | nil
+  @spec get(integer) :: {:ok, Permission.t()} | {:error, atom}
   def get(id) do
     QH.get(Permission, id, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -38,7 +38,7 @@ defmodule Snitch.Data.Model.Product do
   @doc """
   Returns all Products with the given parameters.
   """
-  @spec get(map | non_neg_integer) :: Product.t() | nil
+  @spec get(map | non_neg_integer) :: {:ok, Product.t()} | {:error, atom}
   def get(query_params) do
     QH.get(Product, query_params, Repo)
   end
@@ -184,7 +184,7 @@ defmodule Snitch.Data.Model.Product do
   """
   @spec get(integer) :: {:ok, Product.t()} | {:error, Ecto.Changeset.t()} | nil
   def delete(id) do
-    with %Product{} = product <- get(id),
+    with {:ok, %Product{} = product} <- get(id),
          _ <- ESProductStore.update_product_to_es(product, :delete),
          changeset <- Product.delete_changeset(product) do
       product = product |> Repo.preload(:images)
@@ -327,10 +327,10 @@ defmodule Snitch.Data.Model.Product do
   defp get_image(multi, image_id) do
     Multi.run(multi, :image, fn _ ->
       case QH.get(Image, image_id, Repo) do
-        nil ->
+        {:error, _} ->
           {:error, "image not found"}
 
-        image ->
+        {:ok, image} ->
           {:ok, image}
       end
     end)
@@ -339,10 +339,10 @@ defmodule Snitch.Data.Model.Product do
   defp get_product(multi, product_id) do
     Multi.run(multi, :product, fn _ ->
       case get(product_id) do
-        nil ->
-          {:error, "prodcut not found"}
+        {:error, _} ->
+          {:error, "product not found"}
 
-        product ->
+        {:ok, product} ->
           {:ok, product}
       end
     end)

--- a/apps/snitch_core/lib/core/data/model/product_brand.ex
+++ b/apps/snitch_core/lib/core/data/model/product_brand.ex
@@ -71,7 +71,7 @@ defmodule Snitch.Data.Model.ProductBrand do
 
   Takes Product Brand id as input.
   """
-  @spec get(integer) :: ProductBrand.t() | nil
+  @spec get(integer) :: {:ok, ProductBrand.t()} | {:error, atom}
   def get(id) do
     QH.get(ProductBrand, id, Repo)
   end
@@ -87,11 +87,12 @@ defmodule Snitch.Data.Model.ProductBrand do
   @spec delete(non_neg_integer() | ProductBrand.t()) ::
           {:ok, ProductBrand.t()} | {:error, Ecto.Changeset.t()} | {:error, :not_found}
   def delete(id) do
-    with %ProductBrand{} = brand <- get(id) |> Repo.preload(:image),
+    with {:ok, %ProductBrand{} = brand_struct} <- get(id),
+         brand <- brand_struct |> Repo.preload(:image),
          changeset <- ProductBrand.delete_changeset(brand, %{}) do
       delete_product_brand(brand, brand.image, changeset)
     else
-      nil -> {:error, :not_found}
+      {:error, msg} -> {:error, msg}
     end
   end
 

--- a/apps/snitch_core/lib/core/data/model/product_option_value.ex
+++ b/apps/snitch_core/lib/core/data/model/product_option_value.ex
@@ -21,7 +21,7 @@ defmodule Snitch.Data.Model.ProductOptionValue do
 
   Takes Product Option Value id as input
   """
-  @spec get(integer) :: ProductOptionValue.t() | nil
+  @spec get(integer) :: {:ok, ProductOptionValue.t()} | {:error, atom}
   def get(id) do
     QH.get(ProductOptionValue, id, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/product_property.ex
+++ b/apps/snitch_core/lib/core/data/model/product_property.ex
@@ -56,12 +56,12 @@ defmodule Snitch.Data.Model.ProductProperty do
 
   Takes ProductProperty id as input
   """
-  @spec get(integer) :: ProductProperty.t() | nil
+  @spec get(integer) :: {:ok, ProductProperty.t()} | {:error, atom}
   def get(id) do
     QH.get(ProductProperty, id, Repo)
   end
 
-  @spec get(map | non_neg_integer) :: ProductProperty.t() | nil
+  @spec get(map | non_neg_integer) :: {:ok, ProductProperty.t()} | {:error, atom}
   def get_by(query_fields_or_primary_key) do
     QH.get(ProductProperty, query_fields_or_primary_key, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/product_prototype.ex
+++ b/apps/snitch_core/lib/core/data/model/product_prototype.ex
@@ -27,7 +27,7 @@ defmodule Snitch.Data.Model.ProductPrototype do
 
   Takes Product Prototype id as input
   """
-  @spec get(integer) :: ProductPrototype.t() | nil
+  @spec get(integer) :: {:ok, ProductPrototype.t()} | {:error, atom}
   def get(id) do
     QH.get(ProductPrototype, id, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/promotion/promotion.ex
+++ b/apps/snitch_core/lib/core/data/model/promotion/promotion.ex
@@ -99,9 +99,16 @@ defmodule Snitch.Data.Model.Promotion do
     QH.update(Promotion, params, promotion, Repo)
   end
 
-  @spec get(map) :: Promotion.t() | nil
+  @spec get(map) :: {:ok, Promotion.t()} | {:error, atom}
   def get(query_fields) do
-    Promotion |> QH.get(query_fields, Repo) |> Repo.preload([:actions, :rules])
+    case Promotion |> QH.get(query_fields, Repo) do
+      {:ok, promotion} ->
+        promotion = promotion |> Repo.preload([:actions, :rules])
+        {:ok, promotion}
+
+      {:error, msg} ->
+        {:error, msg}
+    end
   end
 
   @doc """

--- a/apps/snitch_core/lib/core/data/model/property.ex
+++ b/apps/snitch_core/lib/core/data/model/property.ex
@@ -35,7 +35,7 @@ defmodule Snitch.Data.Model.Property do
 
   Takes Property id as input
   """
-  @spec get(integer) :: Property.t() | nil
+  @spec get(integer) :: {:ok, Property.t()} | {:error, atom}
   def get(id) do
     QH.get(Property, id, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/rating.ex
+++ b/apps/snitch_core/lib/core/data/model/rating.ex
@@ -17,12 +17,12 @@ defmodule Snitch.Data.Model.Rating do
   @doc """
   Returns a `rating` by the supplied `id`.
   """
-  @spec get(non_neg_integer) :: Rating.t() | nil
+  @spec get(non_neg_integer) :: {:ok, Rating.t()} | {:error, atom}
   def get(id) do
     QH.get(Rating, id, Repo)
   end
 
-  @spec get_rating_option(non_neg_integer) :: RatingOption.t() | nil
+  @spec get_rating_option(non_neg_integer) :: {:ok, RatingOption.t()} | {:error, atom}
   def get_rating_option(id) do
     QH.get(RatingOption, id, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/review.ex
+++ b/apps/snitch_core/lib/core/data/model/review.ex
@@ -44,7 +44,7 @@ defmodule Snitch.Data.Model.Review do
   @doc """
   Returns a review for the supplied `id`
   """
-  @spec get(non_neg_integer) :: Review.t() :: nil
+  @spec get(non_neg_integer) :: {:ok, Review.t()} | {:error, atom}
   def get(id) do
     QH.get(Review, id, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/role.ex
+++ b/apps/snitch_core/lib/core/data/model/role.ex
@@ -87,7 +87,7 @@ defmodule Snitch.Data.Model.Role do
 
   Takes as input `id` of the role to be retrieved.
   """
-  @spec get(integer) :: Role.t() | nil
+  @spec get(integer) :: {:ok, Role.t()} | {:error, atom}
   def get(id) do
     QH.get(Role, id, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/shipping_category.ex
+++ b/apps/snitch_core/lib/core/data/model/shipping_category.ex
@@ -34,10 +34,17 @@ defmodule Snitch.Data.Model.ShippingCategory do
 
   Takes as input `id` of the `shipping_category` to be retrieved.
   """
-  @spec get_with_rules(non_neg_integer) :: ShippingCategory.t() | nil
+  @spec get_with_rules(non_neg_integer) :: {:ok, ShippingCategory.t()} | {:error, atom}
   def get_with_rules(id) do
-    ShippingCategory
-    |> QH.get(id, Repo)
-    |> Repo.preload(shipping_rules: :shipping_rule_identifier)
+    case QH.get(ShippingCategory, id, Repo) do
+      {:ok, shipping_category} ->
+        shipping_category =
+          shipping_category |> Repo.preload(shipping_rules: :shipping_rule_identifier)
+
+        {:ok, shipping_category}
+
+      {:error, msg} ->
+        {:error, msg}
+    end
   end
 end

--- a/apps/snitch_core/lib/core/data/model/shipping_method.ex
+++ b/apps/snitch_core/lib/core/data/model/shipping_method.ex
@@ -77,7 +77,7 @@ defmodule Snitch.Data.Model.ShippingMethod do
     QH.delete(SM, id_or_instance, Repo)
   end
 
-  @spec get(map | non_neg_integer) :: SM.t() | nil
+  @spec get(map | non_neg_integer) :: {:ok, SM.t()} | {:error, atom}
   def get(query_fields_or_primary_key) do
     QH.get(SM, query_fields_or_primary_key, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/shipping_rule.ex
+++ b/apps/snitch_core/lib/core/data/model/shipping_rule.ex
@@ -23,7 +23,7 @@ defmodule Snitch.Data.Model.ShippingRule do
   @doc """
   Returns a `shipping rule` by the supplied `id`.
   """
-  @spec get(non_neg_integer) :: ShippingRule.t() | nil
+  @spec get(non_neg_integer) :: {:ok, ShippingRule.t()} | {:error, atom}
   def get(id) do
     QH.get(ShippingRule, id, Repo)
     |> Repo.preload([:shipping_category, :shipping_rule_identifier])

--- a/apps/snitch_core/lib/core/data/model/state.ex
+++ b/apps/snitch_core/lib/core/data/model/state.ex
@@ -7,7 +7,7 @@ defmodule Snitch.Data.Model.State do
 
   alias Snitch.Data.Schema.State
 
-  @spec get(map | non_neg_integer) :: State.t() | nil
+  @spec get(map | non_neg_integer) :: {:ok, State.t()} | {:error, atom}
   def get(query_fields_or_primary_key) do
     QH.get(State, query_fields_or_primary_key, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/stock/stock_item.ex
+++ b/apps/snitch_core/lib/core/data/model/stock/stock_item.ex
@@ -36,7 +36,7 @@ defmodule Snitch.Data.Model.StockItem do
     QH.delete(StockItemSchema, id_or_instance, Repo)
   end
 
-  @spec get(non_neg_integer | map) :: StockItemSchema.t()
+  @spec get(non_neg_integer | map) :: {:ok, StockItemSchema.t()} | {:error, atom}
   def get(query_fields) do
     QH.get(StockItemSchema, query_fields, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/stock/stock_location.ex
+++ b/apps/snitch_core/lib/core/data/model/stock/stock_location.ex
@@ -23,7 +23,7 @@ defmodule Snitch.Data.Model.StockLocation do
     QH.delete(StockLocationSchema, id_or_instance, Repo)
   end
 
-  @spec get(integer() | map) :: StockLocationSchema.t()
+  @spec get(integer() | map) :: {:ok, StockLocationSchema.t()} | {:error, atom}
   def get(query_fields) do
     QH.get(StockLocationSchema, query_fields, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/stock/stock_movement.ex
+++ b/apps/snitch_core/lib/core/data/model/stock/stock_movement.ex
@@ -18,7 +18,7 @@ defmodule Snitch.Data.Model.StockMovement do
     )
   end
 
-  @spec get(non_neg_integer | map) :: StockMovementSchema.t()
+  @spec get(non_neg_integer | map) :: {:ok, StockMovementSchema.t()} | {:error, atom}
   def get(query_fields) do
     QH.get(StockMovementSchema, query_fields, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/stock/stock_transfer.ex
+++ b/apps/snitch_core/lib/core/data/model/stock/stock_transfer.ex
@@ -21,7 +21,7 @@ defmodule Snitch.Data.Model.StockTransfer do
     )
   end
 
-  @spec get(non_neg_integer | map) :: StockTransferSchema.t()
+  @spec get(non_neg_integer | map) :: {:ok, StockTransferSchema.t()} | {:error, atom}
   def get(query_fields), do: QH.get(StockTransferSchema, query_fields, Repo)
 
   @doc """

--- a/apps/snitch_core/lib/core/data/model/tax_category.ex
+++ b/apps/snitch_core/lib/core/data/model/tax_category.ex
@@ -115,7 +115,7 @@ defmodule Snitch.Data.Model.TaxCategory do
   > Note, By default tax category which is present in the table
   and is __not soft deleted__ is returned.
   """
-  @spec get(integer, boolean) :: TaxCategory.t() | nil
+  @spec get(integer, boolean) :: {:ok, TaxCategory.t()} | {:error, atom}
   def get(id, active \\ true) do
     if active do
       query = from(tc in TaxCategory, where: is_nil(tc.deleted_at) and tc.id == ^id)

--- a/apps/snitch_core/lib/core/data/model/tax_rate.ex
+++ b/apps/snitch_core/lib/core/data/model/tax_rate.ex
@@ -60,7 +60,7 @@ defmodule Snitch.Data.Model.TaxRate do
   > Note, By default tax rate which is present in the table
   and is __not soft deleted__ is returned.
   """
-  @spec get(integer, boolean) :: TaxRate.t() | nil
+  @spec get(integer, boolean) :: {:ok, TaxRate.t()} | {:error, atom}
   def get(id, active \\ true) do
     if active do
       query = from(tc in TaxRate, where: is_nil(tc.deleted_at) and tc.id == ^id)

--- a/apps/snitch_core/lib/core/data/model/user.ex
+++ b/apps/snitch_core/lib/core/data/model/user.ex
@@ -17,7 +17,8 @@ defmodule Snitch.Data.Model.User do
 
   @spec delete(non_neg_integer) :: {:ok, Ecto.Schema.t()} | {:error, Ecto.Changeset.t()}
   def delete(id) do
-    with %UserSchema{} = user <- get(id) |> Repo.preload(:orders),
+    with {:ok, %UserSchema{} = user_struct} <- get(id),
+         user <- user_struct |> Repo.preload(:orders),
          {:ok, _} = delete_response <- UserSchema.delete_changeset(user, %{}) |> Repo.delete() do
       delete_response
     else
@@ -26,7 +27,7 @@ defmodule Snitch.Data.Model.User do
     end
   end
 
-  @spec get(map | non_neg_integer) :: UserSchema.t() | nil
+  @spec get(map | non_neg_integer) :: {:ok, UserSchema.t()} | {:error, atom}
   def get(query_fields_or_primary_key) do
     QH.get(UserSchema, query_fields_or_primary_key, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/variation_theme.ex
+++ b/apps/snitch_core/lib/core/data/model/variation_theme.ex
@@ -24,7 +24,7 @@ defmodule Snitch.Data.Model.VariationTheme do
   @doc """
   Takes Variation theme id as input
   """
-  @spec get(integer) :: VariationTheme.t() | nil
+  @spec get(integer) :: {:ok, VariationTheme.t()} | {:error, atom}
   def get(id) do
     QH.get(VariationTheme, id, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/zone/country_zone.ex
+++ b/apps/snitch_core/lib/core/data/model/zone/country_zone.ex
@@ -37,7 +37,7 @@ defmodule Snitch.Data.Model.CountryZone do
     QH.delete(Zone, id_or_instance, Repo)
   end
 
-  @spec get(map | non_neg_integer) :: Zone.t() | nil
+  @spec get(map | non_neg_integer) :: {:ok, Zone.t()} | {:error, atom}
   def get(query_fields_or_primary_key) do
     QH.get(Zone, query_fields_or_primary_key, Repo)
   end

--- a/apps/snitch_core/lib/core/data/model/zone/state_zone.ex
+++ b/apps/snitch_core/lib/core/data/model/zone/state_zone.ex
@@ -37,7 +37,7 @@ defmodule Snitch.Data.Model.StateZone do
     QH.delete(Zone, id_or_instance, Repo)
   end
 
-  @spec get(map | non_neg_integer) :: Zone.t() | nil
+  @spec get(map | non_neg_integer) :: {:ok, Zone.t()} | {:error, atom}
   def get(query_fields_or_primary_key) do
     QH.get(Zone, query_fields_or_primary_key, Repo)
   end

--- a/apps/snitch_core/lib/core/domain/account/account.ex
+++ b/apps/snitch_core/lib/core/domain/account/account.ex
@@ -19,7 +19,16 @@ defmodule Snitch.Domain.Account do
 
   @spec authenticate(String.t(), String.t()) :: {:ok, UserSchema.t()} | {:error, :not_found}
   def authenticate(email, password) do
-    verify_email(User.get(%{email: email}) |> Repo.preload(:role), password)
+    user =
+      case User.get(%{email: email}) do
+        {:ok, user} ->
+          user |> Repo.preload(:role)
+
+        {:error, _} ->
+          nil
+      end
+
+    verify_email(user, password)
   end
 
   defp verify_email(nil, _) do

--- a/apps/snitch_core/lib/core/domain/stock/inventory.ex
+++ b/apps/snitch_core/lib/core/domain/stock/inventory.ex
@@ -50,9 +50,9 @@ defmodule Snitch.Domain.Inventory do
   @spec reduce_stock(integer, integer, integer) ::
           {:ok, StockSchema.t()} | {:error, Ecto.Changeset.t() | :variant_not_found}
   def reduce_stock(product_id, stock_location_id, reduce_count) do
-    with product <- ProductModel.get(product_id),
+    with {:ok, product} <- ProductModel.get(product_id),
          product_with_inventory <- ProductModel.product_with_inventory_tracking(product),
-         stock_location <- SLModel.get(stock_location_id) do
+         {:ok, stock_location} <- SLModel.get(stock_location_id) do
       perform_stock_reduce(product, product_with_inventory, stock_location, reduce_count)
     end
   end
@@ -110,8 +110,8 @@ defmodule Snitch.Domain.Inventory do
     query_fields = %{product_id: product_id, stock_location_id: location_id}
 
     case StockModel.get(query_fields) do
-      %StockSchema{} = stock_item -> {:ok, stock_item}
-      nil -> StockModel.create(product_id, location_id, 0, false)
+      {:ok, %StockSchema{} = stock_item} -> {:ok, stock_item}
+      {:error, _} -> StockModel.create(product_id, location_id, 0, false)
     end
   end
 end

--- a/apps/snitch_core/priv/repo/demo/order.ex
+++ b/apps/snitch_core/priv/repo/demo/order.ex
@@ -41,6 +41,9 @@ defmodule Snitch.Demo.Order do
     variants = Product |> Repo.all() |> Enum.take_random(5)
     user = Repo.all(User) |> Enum.random()
 
+    {:ok, state} = State.get(%{code: "US-CA"})
+    {:ok, country} = Country.get(%{iso: "US"})
+
     address = %OrderAddress{
       first_name: user.first_name,
       last_name: user.last_name,
@@ -48,8 +51,8 @@ defmodule Snitch.Demo.Order do
       zip_code: "90265",
       city: "Malibu",
       phone: "1234567890",
-      state_id: State.get(%{code: "US-CA"}).id,
-      country_id: Country.get(%{iso: "US"}).id
+      state_id: state.id,
+      country_id: country.id
     }
 
     digest = [

--- a/apps/snitch_core/priv/repo/seed/shipping.ex
+++ b/apps/snitch_core/priv/repo/seed/shipping.ex
@@ -39,26 +39,31 @@ defmodule Snitch.Seed.Shipping do
     Repo.all(ShippingCategory)
   end
 
+  defp get_state(code_params) do
+    {:ok, state} = State.get(code_params)
+    state
+  end
+
   def seed_zones! do
     Repo.delete_all(Zone)
     Repo.delete_all(ShippingMethodSchema)
     all_zones = [apac, india, north_india] = zones_with_manifest(@zone_manifest)
 
-    ind = Country.get(%{iso: "IN"})
-    ch = Country.get(%{iso: "CH"})
-    jp = Country.get(%{iso: "JP"})
+    {:ok, ind} = Country.get(%{iso: "IN"})
+    {:ok, ch} = Country.get(%{iso: "CH"})
+    {:ok, jp} = Country.get(%{iso: "JP"})
 
     states = Repo.all(from(s in StateSchema, where: s.country_id == ^ind.id))
 
     northern = [
-      State.get(%{code: "IN-UP"}),
-      State.get(%{code: "IN-BR"}),
-      State.get(%{code: "IN-CH"}),
-      State.get(%{code: "IN-CT"}),
-      State.get(%{code: "IN-DL"}),
-      State.get(%{code: "IN-RJ"}),
-      State.get(%{code: "IN-UT"}),
-      State.get(%{code: "IN-PB"})
+      get_state(%{code: "IN-UP"}),
+      get_state(%{code: "IN-BR"}),
+      get_state(%{code: "IN-CH"}),
+      get_state(%{code: "IN-CT"}),
+      get_state(%{code: "IN-DL"}),
+      get_state(%{code: "IN-RJ"}),
+      get_state(%{code: "IN-UT"}),
+      get_state(%{code: "IN-PB"})
     ]
 
     zone_members([

--- a/apps/snitch_core/priv/repo/seed/stocks.ex
+++ b/apps/snitch_core/priv/repo/seed/stocks.ex
@@ -31,7 +31,25 @@ defmodule Snitch.Seed.Stocks do
     end)
   end
 
+  defp get_id({:ok, struct}) do
+    struct.id
+  end
+
   def seed_stock_locations! do
+    states = %{
+      state1: State.get(%{code: "US-NY"}) |> get_id,
+      state2: State.get(%{code: "IN-UP"}) |> get_id,
+      state3: State.get(%{code: "IT-RM"}) |> get_id,
+      state4: State.get(%{code: "IN-MH"}) |> get_id
+    }
+
+    countries = %{
+      country1: Country.get(%{iso: "US"}) |> get_id,
+      country2: Country.get(%{iso: "IN"}) |> get_id,
+      country3: Country.get(%{iso: "IT"}) |> get_id,
+      country4: Country.get(%{iso: "IN"}) |> get_id
+    }
+
     locations =
       [
         %{
@@ -44,8 +62,8 @@ defmodule Snitch.Seed.Stocks do
           phone: "(212) 363-3200",
           propagate_all_variants: false,
           active: true,
-          state_id: State.get(%{code: "US-NY"}).id,
-          country_id: Country.get(%{iso: "US"}).id
+          state_id: states.state1,
+          country_id: countries.country1
         },
         %{
           name: "Taj Mahal",
@@ -56,8 +74,8 @@ defmodule Snitch.Seed.Stocks do
           phone: "+91-562-2227261",
           propagate_all_variants: false,
           active: true,
-          state_id: State.get(%{code: "IN-UP"}).id,
-          country_id: Country.get(%{iso: "IN"}).id
+          state_id: states.state2,
+          country_id: countries.country2
         },
         %{
           name: "Colosseum",
@@ -68,8 +86,8 @@ defmodule Snitch.Seed.Stocks do
           phone: "+39 06 3996 7700",
           propagate_all_variants: false,
           active: true,
-          state_id: State.get(%{code: "IT-RM"}).id,
-          country_id: Country.get(%{iso: "IT"}).id
+          state_id: states.state3,
+          country_id: countries.country3
         },
         %{
           name: "Sinhagadh Fort",
@@ -80,8 +98,8 @@ defmodule Snitch.Seed.Stocks do
           phone: "020 2612 8169",
           propagate_all_variants: false,
           active: true,
-          state_id: State.get(%{code: "IN-MH"}).id,
-          country_id: Country.get(%{iso: "IN"}).id
+          state_id: states.state4,
+          country_id: countries.country4
         }
       ]
       |> Stream.map(&Map.put(&1, :inserted_at, Ecto.DateTime.utc()))

--- a/apps/snitch_core/priv/repo/seed/users.ex
+++ b/apps/snitch_core/priv/repo/seed/users.ex
@@ -36,8 +36,24 @@ defmodule Snitch.Seed.Users do
     }
   end
 
+  defp get_id({:ok, struct}) do
+    struct.id
+  end
+
   def seed_address! do
     Repo.delete_all(Address)
+
+    states = %{
+      state1: State.get(%{code: "US-CA"}) |> get_id,
+      state2: State.get(%{code: "IN-MH"}) |> get_id,
+      state3: State.get(%{code: "IN-BR"}) |> get_id
+    }
+
+    countries = %{
+      country1: Country.get(%{iso: "US"}) |> get_id,
+      country2: Country.get(%{iso: "IN"}) |> get_id,
+      country3: Country.get(%{iso: "IN"}) |> get_id
+    }
 
     Enum.map(
       [
@@ -48,8 +64,8 @@ defmodule Snitch.Seed.Users do
           zip_code: "90265",
           city: "Malibu",
           phone: "1234567890",
-          state_id: State.get(%{code: "US-CA"}).id,
-          country_id: Country.get(%{iso: "US"}).id
+          state_id: states.state1,
+          country_id: countries.country1
         },
         %Address{
           first_name: "noname",
@@ -59,8 +75,8 @@ defmodule Snitch.Seed.Users do
           zip_code: "00000",
           city: "Pune",
           phone: "1234567890",
-          state_id: State.get(%{code: "IN-MH"}).id,
-          country_id: Country.get(%{iso: "IN"}).id
+          state_id: states.state2,
+          country_id: countries.country2
         },
         %Address{
           first_name: "noname",
@@ -70,8 +86,8 @@ defmodule Snitch.Seed.Users do
           zip_code: "11111",
           city: "Patna",
           phone: "1234567890",
-          state_id: State.get(%{code: "IN-BR"}).id,
-          country_id: Country.get(%{iso: "IN"}).id
+          state_id: states.state3,
+          country_id: countries.country3
         }
       ],
       &Repo.insert!/1

--- a/apps/snitch_core/test/data/model/country_test.exs
+++ b/apps/snitch_core/test/data/model/country_test.exs
@@ -17,18 +17,18 @@ defmodule Snitch.Data.Model.CountryTest do
   describe "get/1" do
     test "succeeds", %{countries: countries} do
       country = countries |> List.first()
-      country_list = Country.get(%{numcode: country.numcode})
+      {:ok, country_list} = Country.get(%{numcode: country.numcode})
       assert country_list == country
     end
 
     test "fails" do
       country_list = Country.get(%{numcode: "842"})
-      assert country_list == nil
+      assert country_list == {:error, :country_not_found}
     end
   end
 
   describe "get_all/0" do
-    test "succeds", %{countries: countries} do
+    test "succeeds", %{countries: countries} do
       country_list = Country.get_all()
       assert length(country_list) == length(countries)
     end

--- a/apps/snitch_core/test/data/model/line_item_test.exs
+++ b/apps/snitch_core/test/data/model/line_item_test.exs
@@ -124,10 +124,10 @@ defmodule Snitch.Data.Model.LineItemTest do
       [line_item] = order.line_items
 
       {:ok, _} = LineItem.delete(line_item)
+      {:ok, order} = Order.get(order.id)
 
       assert [] =
-               order.id
-               |> Order.get()
+               order
                |> Repo.preload(:line_items)
                |> Map.fetch!(:line_items)
     end

--- a/apps/snitch_core/test/data/model/permission_test.exs
+++ b/apps/snitch_core/test/data/model/permission_test.exs
@@ -37,10 +37,10 @@ defmodule Snitch.Data.Model.PermissionTest do
 
   test "get permission" do
     permission = insert(:permission)
-    assert permission_returned = Permission.get(permission.id)
+    assert {:ok, permission_returned} = Permission.get(permission.id)
     assert permission_returned == permission
     assert {:ok, _} = Permission.delete(permission.id)
-    assert Permission.get(permission.id) == nil
+    assert Permission.get(permission.id) == {:error, :permission_not_found}
   end
 
   test "get all permissions" do

--- a/apps/snitch_core/test/data/model/product_property_test.exs
+++ b/apps/snitch_core/test/data/model/product_property_test.exs
@@ -73,10 +73,10 @@ defmodule Snitch.Data.Model.ProductPropertyTest do
   describe "get" do
     test "get product property" do
       product_property = insert(:product_property)
-      assert product_property_returned = ProductProperty.get(product_property.id)
+      assert {:ok, product_property_returned} = ProductProperty.get(product_property.id)
       assert product_property_returned.id == product_property.id
       assert {:ok, _} = ProductProperty.delete(product_property)
-      assert ProductProperty.get(product_property.id) == nil
+      assert ProductProperty.get(product_property.id) == {:error, :product_property_not_found}
     end
 
     test "get all product properties" do
@@ -89,7 +89,7 @@ defmodule Snitch.Data.Model.ProductPropertyTest do
     test "get product property" do
       product_property = insert(:product_property)
 
-      assert product_property_returned =
+      assert {:ok, product_property_returned} =
                ProductProperty.get_by(%{
                  product_id: product_property.product_id,
                  property_id: product_property.property_id

--- a/apps/snitch_core/test/data/model/product_test.exs
+++ b/apps/snitch_core/test/data/model/product_test.exs
@@ -85,10 +85,10 @@ defmodule Snitch.Data.Model.ProductTest do
 
   describe "get" do
     test "product", %{valid_attrs: va} do
-      assert product_returned = Product.get(va.product_id)
+      assert {:ok, product_returned} = Product.get(va.product_id)
       assert product_returned.id == va.product_id
       assert {:ok, _} = Product.delete(va.product_id)
-      product_deleted = Product.get(va.product_id)
+      {:ok, product_deleted} = Product.get(va.product_id)
       assert product_deleted.state == :deleted
     end
 
@@ -135,7 +135,7 @@ defmodule Snitch.Data.Model.ProductTest do
     test "products with name, state, slug" do
       product = insert(:product)
 
-      assert product_returned =
+      assert {:ok, product_returned} =
                Product.get(%{
                  state: product.state,
                  name: product.name,
@@ -271,12 +271,12 @@ defmodule Snitch.Data.Model.ProductTest do
       assert {:ok, _} = Product.delete(product.id)
 
       product_returned = Repo.get(ProductSchema, product.id)
-      assert product_returned != nil
+      refute product_returned == nil
       assert product_returned.state == :deleted
     end
 
     test "fails product not found" do
-      assert Product.delete(-1) == nil
+      assert Product.delete(-1) == {:error, :product_not_found}
     end
   end
 
@@ -419,7 +419,7 @@ defmodule Snitch.Data.Model.ProductTest do
       {:ok, _} = Product.delete_by_category(casual_shirt)
 
       products_by_category = Product.get_products_by_category(casual_shirt.id)
-      deleted_products = products_ids |> Enum.map(&Product.get/1)
+      deleted_products = products_ids |> Enum.map(&get_product(Product.get(&1)))
 
       assert length(products_by_category) == 0
 
@@ -429,6 +429,10 @@ defmodule Snitch.Data.Model.ProductTest do
         assert product.taxon_id == nil
       end)
     end
+  end
+
+  defp get_product({:ok, product}) do
+    product
   end
 
   describe "has_variants?/1" do

--- a/apps/snitch_core/test/data/model/property_test.exs
+++ b/apps/snitch_core/test/data/model/property_test.exs
@@ -37,10 +37,10 @@ defmodule Snitch.Data.Model.PropertyTest do
   describe "get/1" do
     test "with id" do
       property = insert(:property)
-      assert property_returned = Property.get(property.id)
+      assert {:ok, property_returned} = Property.get(property.id)
       assert property_returned = property
       assert {:ok, _} = Property.delete(property.id)
-      assert Property.get(property.id) == nil
+      assert Property.get(property.id) == {:error, :property_not_found}
     end
   end
 

--- a/apps/snitch_core/test/data/model/role_test.exs
+++ b/apps/snitch_core/test/data/model/role_test.exs
@@ -60,10 +60,10 @@ defmodule Snitch.Data.Model.RoleTest do
 
   test "get role" do
     role = insert(:role)
-    assert role_returned = Role.get(role.id)
+    assert {:ok, role_returned} = Role.get(role.id)
     assert role_returned.id == role.id
     assert {:ok, _} = Role.delete(role)
-    assert Role.get(role.id) == nil
+    assert Role.get(role.id) == {:error, :role_not_found}
   end
 
   test "get all roles" do

--- a/apps/snitch_core/test/data/model/state_test.exs
+++ b/apps/snitch_core/test/data/model/state_test.exs
@@ -9,13 +9,13 @@ defmodule Snitch.Data.Model.StateTest do
   describe "get/1 " do
     test "succeeds", %{states: states} do
       states = states |> List.first()
-      state = State.get(%{name: "California"})
+      {:ok, state} = State.get(%{name: "California"})
       assert state.name == states.name
     end
 
     test "Fails " do
-      state = State.get(%{name: "Japan"})
-      assert state == nil
+      {:error, msg} = State.get(%{name: "Japan"})
+      assert msg == :state_not_found
     end
   end
 

--- a/apps/snitch_core/test/data/model/stock/stock_item_test.exs
+++ b/apps/snitch_core/test/data/model/stock/stock_item_test.exs
@@ -39,20 +39,20 @@ defmodule Snitch.Data.Model.StockItemTest do
   describe "get/1" do
     test "Fails with invalid id" do
       stock_item = StockItemModel.get(-1)
-      assert nil == stock_item
+      assert {:error, :stock_item_not_found} == stock_item
     end
 
     test "gets with valid id" do
       insert_stock_item = insert(:stock_item)
 
-      get_stock_item = StockItemModel.get(insert_stock_item.id)
+      {:ok, get_stock_item} = StockItemModel.get(insert_stock_item.id)
       assert insert_stock_item.id == get_stock_item.id
       assert insert_stock_item.stock_location_id == get_stock_item.stock_location_id
       assert insert_stock_item.product_id == get_stock_item.product_id
       assert insert_stock_item.count_on_hand == get_stock_item.count_on_hand
 
       # with stock item map
-      get_stock_item_with_map = StockItemModel.get(%{id: insert_stock_item.id})
+      {:ok, get_stock_item_with_map} = StockItemModel.get(%{id: insert_stock_item.id})
       assert insert_stock_item.id == get_stock_item_with_map.id
       assert insert_stock_item.stock_location_id == get_stock_item_with_map.stock_location_id
       assert insert_stock_item.product_id == get_stock_item_with_map.product_id

--- a/apps/snitch_core/test/data/model/stock/stock_location_test.exs
+++ b/apps/snitch_core/test/data/model/stock/stock_location_test.exs
@@ -60,18 +60,18 @@ defmodule Snitch.Data.Model.StockLocationTest do
   describe "get/1" do
     test "Fails with invalid id" do
       stock_location = StockLocationModel.get(-1)
-      assert nil == stock_location
+      assert {:error, :stock_location_not_found} == stock_location
     end
 
     test "gets with valid id" do
       insert_stock_location = insert(:stock_location)
 
-      get_stock_location = StockLocationModel.get(insert_stock_location.id)
+      {:ok, get_stock_location} = StockLocationModel.get(insert_stock_location.id)
       assert insert_stock_location.id == get_stock_location.id
       assert insert_stock_location.name == get_stock_location.name
 
       # with stock location map
-      get_stock_location_with_map = StockLocationModel.get(%{id: insert_stock_location.id})
+      {:ok, get_stock_location_with_map} = StockLocationModel.get(%{id: insert_stock_location.id})
       assert insert_stock_location.id == get_stock_location_with_map.id
       assert insert_stock_location.name == get_stock_location_with_map.name
     end

--- a/apps/snitch_core/test/data/model/stock/stock_movement_test.exs
+++ b/apps/snitch_core/test/data/model/stock/stock_movement_test.exs
@@ -34,14 +34,14 @@ defmodule Snitch.Data.Model.StockMovementTest do
   describe "get/1" do
     test "Fails with invalid id" do
       stock_item = StockMovementModel.get(1)
-      assert nil == stock_item
+      assert {:error, :stock_movement_not_found} == stock_item
     end
 
     test "gets with valid id", context do
       %{stock_item: stock_item} = context
       insert_stock_movement = insert(:stock_movement, stock_item: stock_item)
 
-      get_stock_movement = StockMovementModel.get(insert_stock_movement.id)
+      {:ok, get_stock_movement} = StockMovementModel.get(insert_stock_movement.id)
       assert insert_stock_movement.id == get_stock_movement.id
       assert insert_stock_movement.stock_item_id == stock_item.id
       assert insert_stock_movement.quantity == get_stock_movement.quantity
@@ -50,7 +50,7 @@ defmodule Snitch.Data.Model.StockMovementTest do
       assert insert_stock_movement.originator_id == get_stock_movement.originator_id
 
       # with stock item map
-      get_stock_movement_with_map = StockMovementModel.get(%{id: insert_stock_movement.id})
+      {:ok, get_stock_movement_with_map} = StockMovementModel.get(%{id: insert_stock_movement.id})
       assert insert_stock_movement.id == get_stock_movement_with_map.id
       assert insert_stock_movement.stock_item_id == stock_item.id
       assert insert_stock_movement.quantity == get_stock_movement_with_map.quantity

--- a/apps/snitch_core/test/domain/stock/inventory_test.exs
+++ b/apps/snitch_core/test/domain/stock/inventory_test.exs
@@ -12,7 +12,7 @@ defmodule Snitch.Domain.PackageItemTest do
       variant = insert(:variant)
 
       stock_query_map = %{product_id: variant.id, stock_location_id: stock_location.id}
-      assert StockItem.get(stock_query_map) == nil
+      assert StockItem.get(stock_query_map) == {:error, :stock_item_not_found}
 
       stock_params = %{
         "product_id" => variant.id,
@@ -38,7 +38,7 @@ defmodule Snitch.Domain.PackageItemTest do
       assert stock_item.inventory_warning_level == 3
     end
 
-    test "stock less then 0" do
+    test "stock less than 0" do
       stock_location = insert(:stock_location)
       variant = insert(:variant)
 
@@ -77,7 +77,7 @@ defmodule Snitch.Domain.PackageItemTest do
       assert product.inventory_tracking == :product
 
       stock_query_map = %{product_id: product.id, stock_location_id: stock_location.id}
-      stock_item = StockItem.get(stock_query_map)
+      {:ok, stock_item} = StockItem.get(stock_query_map)
 
       assert stock_item.count_on_hand == 10
       assert stock_item.inventory_warning_level == 0


### PR DESCRIPTION
## Why?
To make the return type consistent throughout the app for getter functions. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
Returning following response tuples:
1. {:ok, struct} for success response.
2. {:error, message} for unsuccessful response.
<!--- List and detail all changes made in this PR. -->

[delivers #163217522](https://www.pivotaltracker.com/story/show/163217522)