### PR TITLE
fix pattern match for get property response

### DIFF
--- a/apps/admin_app/lib/admin_app_web/controllers/product_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/product_controller.ex
@@ -434,7 +434,7 @@ defmodule AdminAppWeb.ProductController do
   end
 
   def update_property(conn, params) do
-    with %ProductProperty{} = product_property <-
+    with {:ok, %ProductProperty{} = product_property} <-
            Model.ProductProperty.get_by(%{
              product_id: params["product_property"]["product_id"],
              property_id: params["product_property"]["property_id"]
@@ -448,7 +448,7 @@ defmodule AdminAppWeb.ProductController do
   end
 
   def delete_property(conn, params) do
-    with %ProductProperty{} = product_property <-
+    with {:ok, %ProductProperty{} = product_property} <-
            Model.ProductProperty.get_by(%{
              product_id: params["product_id"],
              property_id: params["property_id"]

--- a/apps/snitch_core/test/data/schema/property_test.exs
+++ b/apps/snitch_core/test/data/schema/property_test.exs
@@ -10,17 +10,18 @@ defmodule Snitch.Data.Schema.PropertyTest do
 
   describe "create_changeset/2" do
     test "with valid attributes" do
-      %{valid?: validity} =  Property.create_changeset(%Property{}, @valid_attrs)
+      %{valid?: validity} = Property.create_changeset(%Property{}, @valid_attrs)
       assert validity
     end
 
     test "where name and display_name cannot be blank" do
       cs = %{valid?: validity} = Property.create_changeset(%Property{}, %{})
       refute validity
+
       assert %{
-        display_name: ["can't be blank"],
-        name: ["can't be blank"]
-      } == errors_on(cs)
+               display_name: ["can't be blank"],
+               name: ["can't be blank"]
+             } == errors_on(cs)
     end
 
     test "where name must be unique" do
@@ -38,8 +39,8 @@ defmodule Snitch.Data.Schema.PropertyTest do
       [
         property:
           %Property{}
-            |> Property.create_changeset(@valid_attrs)
-            |> apply_changes()
+          |> Property.create_changeset(@valid_attrs)
+          |> apply_changes()
       ]
     end
 
@@ -53,10 +54,11 @@ defmodule Snitch.Data.Schema.PropertyTest do
       params = %{name: "", display_name: ""}
       cs = %{valid?: validity} = Property.update_changeset(property, params)
       refute validity
+
       assert %{
-                name: ["can't be blank"],
-                display_name: ["can't be blank"]
-      } == errors_on(cs)
+               name: ["can't be blank"],
+               display_name: ["can't be blank"]
+             } == errors_on(cs)
     end
 
     test "where name must be unique", %{property: property} do
@@ -65,7 +67,7 @@ defmodule Snitch.Data.Schema.PropertyTest do
       assert {:ok, _} = Repo.insert(changeset)
 
       params = %{name: "material", display_name: "Material"}
-      changeset =  Property.update_changeset(property, params)
+      changeset = Property.update_changeset(property, params)
       assert {:error, cs} = Repo.insert(changeset)
       assert %{name: ["has already been taken"]} = errors_on(cs)
     end


### PR DESCRIPTION
## Why?
To pattern match the success response for product_property's get_by function properly.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
<!--- List and detail all changes made in this PR. -->
Fix pattern for with statement for update/delete property.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

