### PR TITLE
Response tuple fix

### DIFF
--- a/apps/admin_app/lib/admin_app/order/order.ex
+++ b/apps/admin_app/lib/admin_app/order/order.ex
@@ -11,27 +11,43 @@ defmodule AdminApp.OrderContext do
   alias Snitch.Data.Model.Payment
 
   def get_order(%{"number" => number}) do
-    {:ok, order} = OrderModel.get(%{number: number})
+    case OrderModel.get(%{number: number}) do
+      {:ok, order} ->
+        order =
+          order
+          |> Repo.preload([
+            [line_items: :product],
+            [packages: [:items, :shipping_method]],
+            [payments: :payment_method],
+            :user
+          ])
 
-    order
-    |> Repo.preload([
-      [line_items: :product],
-      [packages: [:items, :shipping_method]],
-      [payments: :payment_method],
-      :user
-    ])
+        {:ok, order}
+
+      {:error, msg} ->
+        {:error, msg}
+    end
   end
 
   def get_order(%{"id" => id}) do
     {:ok, order} = id |> String.to_integer() |> OrderModel.get()
 
-    order
-    |> Repo.preload([
-      [line_items: :product],
-      [packages: [:items, :shipping_method]],
-      [payments: :payment_method],
-      :user
-    ])
+    case String.to_integer(id) |> OrderModel.get() do
+      {:ok, order} ->
+        order =
+          order
+          |> Repo.preload([
+            [line_items: :product],
+            [packages: [:items, :shipping_method]],
+            [payments: :payment_method],
+            :user
+          ])
+
+        {:ok, order}
+
+      {:error, msg} ->
+        {:error, msg}
+    end
   end
 
   def get_total(order) do

--- a/apps/admin_app/lib/admin_app_web/controllers/order_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/order_controller.ex
@@ -43,7 +43,7 @@ defmodule AdminAppWeb.OrderController do
   end
 
   def show(conn, %{"number" => _number} = params) do
-    with %OrderSchema{} = order <- OrderContext.get_order(params),
+    with {:ok, %OrderSchema{} = order} <- OrderContext.get_order(params),
          order_total = OrderContext.get_total(order) do
       render(
         conn,
@@ -52,7 +52,7 @@ defmodule AdminAppWeb.OrderController do
         order_total: order_total
       )
     else
-      nil ->
+      {:error, _} ->
         conn
         |> put_flash(:error, "No such order exists with given number")
         |> redirect(to: dashboard_path(conn, :index))

--- a/apps/admin_app/lib/admin_app_web/controllers/product_brand_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/product_brand_controller.ex
@@ -55,13 +55,13 @@ defmodule AdminAppWeb.ProductBrandController do
       |> put_flash(:info, "Product Brand update successfully")
       |> redirect(to: product_brand_path(conn, :index))
     else
-      {:error, changeset} ->
-        render(conn, "edit.html", changeset: %{changeset | action: :edit})
-
-      nil ->
+      {:error, :product_brand_not_found} ->
         conn
         |> put_flash(:info, "Product Brand not found")
         |> redirect(to: product_brand_path(conn, :index))
+
+      {:error, changeset} ->
+        render(conn, "edit.html", changeset: %{changeset | action: :edit})
     end
   end
 

--- a/apps/admin_app/lib/admin_app_web/controllers/promotion_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/promotion_controller.ex
@@ -41,11 +41,6 @@ defmodule AdminAppWeb.PromotionController do
         conn
         |> put_status(422)
         |> render("error_message.json", message: message)
-
-        # nil ->
-        #   conn
-        #   |> put_status(401)
-        #   |> render(AdminAppWeb.ErrorView, "401.json")
     end
   end
 

--- a/apps/admin_app/lib/admin_app_web/controllers/prototype_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/prototype_controller.ex
@@ -48,13 +48,13 @@ defmodule AdminAppWeb.PrototypeController do
       prototypes = PrototypeModel.get_all()
       render(conn, "index.html", prototypes: prototypes)
     else
-      {:error, changeset} ->
-        render(conn, "edit.html", changeset: %{changeset | action: :edit})
-
-      nil ->
+      {:error, :product_prototype_not_found} ->
         conn
         |> put_flash(:info, "Prototype not found")
         |> redirect(to: prototype_path(conn, :index))
+
+      {:error, changeset} ->
+        render(conn, "edit.html", changeset: %{changeset | action: :edit})
     end
   end
 

--- a/apps/snitch_core/lib/core/data/model/tax_category.ex
+++ b/apps/snitch_core/lib/core/data/model/tax_category.ex
@@ -119,9 +119,19 @@ defmodule Snitch.Data.Model.TaxCategory do
   def get(id, active \\ true) do
     if active do
       query = from(tc in TaxCategory, where: is_nil(tc.deleted_at) and tc.id == ^id)
-      Repo.one(query)
+      Repo.one(query) |> format_response
     else
       QH.get(TaxCategory, id, Repo)
+    end
+  end
+
+  defp format_response(response) do
+    case response do
+      nil ->
+        {:error, :tax_category_not_found}
+
+      tax_category ->
+        {:ok, tax_category}
     end
   end
 

--- a/apps/snitch_core/lib/core/data/model/tax_rate.ex
+++ b/apps/snitch_core/lib/core/data/model/tax_rate.ex
@@ -64,9 +64,19 @@ defmodule Snitch.Data.Model.TaxRate do
   def get(id, active \\ true) do
     if active do
       query = from(tc in TaxRate, where: is_nil(tc.deleted_at) and tc.id == ^id)
-      Repo.one(query)
+      Repo.one(query) |> format_response
     else
       QH.get(TaxRate, id, Repo)
+    end
+  end
+
+  defp format_response(response) do
+    case response do
+      nil ->
+        {:error, :tax_rate_not_found}
+
+      tax_rate ->
+        {:ok, tax_rate}
     end
   end
 

--- a/apps/snitch_core/test/data/model/tax_category_test.exs
+++ b/apps/snitch_core/test/data/model/tax_category_test.exs
@@ -144,7 +144,7 @@ defmodule Snitch.Data.Model.TaxCategoryTest do
   describe "get/2" do
     test "tax category" do
       tc = insert(:tax_category)
-      tc_ret = Model.TaxCategory.get(tc.id)
+      {:ok, tc_ret} = Model.TaxCategory.get(tc.id)
       assert tc.id == tc_ret.id
     end
 
@@ -152,15 +152,15 @@ defmodule Snitch.Data.Model.TaxCategoryTest do
       tc = insert(:tax_category)
       assert {:ok, tc} = Model.TaxCategory.delete(tc)
       refute is_nil(tc.deleted_at)
-      tc_ret = Model.TaxCategory.get(tc.id)
-      assert is_nil(tc_ret)
+      {:error, tc_ret} = Model.TaxCategory.get(tc.id)
+      assert tc_ret == :tax_category_not_found
     end
 
     test "tax category, is deleted" do
       tc = insert(:tax_category)
       {:ok, tc} = Model.TaxCategory.delete(tc)
       refute is_nil(tc.deleted_at)
-      tc_ret = Model.TaxCategory.get(tc.id, false)
+      {:ok, tc_ret} = Model.TaxCategory.get(tc.id, false)
       refute is_nil(tc_ret)
     end
   end

--- a/apps/snitch_core/test/data/model/tax_rate_test.exs
+++ b/apps/snitch_core/test/data/model/tax_rate_test.exs
@@ -74,7 +74,7 @@ defmodule Snitch.Data.Model.TaxRateTest do
 
     test "tax rate", context do
       %{tax_rate: tr} = context
-      tr_ret = TaxRateModel.get(tr.id)
+      {:ok, tr_ret} = TaxRateModel.get(tr.id)
       assert tr.id == tr_ret.id
     end
 
@@ -82,15 +82,15 @@ defmodule Snitch.Data.Model.TaxRateTest do
       %{tax_rate: tr} = context
       assert {:ok, tr} = TaxRateModel.delete(tr)
       refute is_nil(tr.deleted_at)
-      tr_ret = TaxRateModel.get(tr.id)
-      assert is_nil(tr_ret)
+      {:error, tr_ret} = TaxRateModel.get(tr.id)
+      assert tr_ret = :tax_rate_not_found
     end
 
-    test "tax category is deleted", context do
+    test "tax rate is deleted", context do
       %{tax_rate: tr} = context
       {:ok, tr} = TaxRateModel.delete(tr)
       refute is_nil(tr.deleted_at)
-      tr_ret = TaxRateModel.get(tr.id, false)
+      {:ok, tr_ret} = TaxRateModel.get(tr.id, false)
       refute is_nil(tr_ret)
     end
   end


### PR DESCRIPTION

## Why?
To pattern match the response considering the current response format.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
1. Fix pattern match for order_controller's show function.
2. Handle get response for tax rate/category according to the current format i.e, - 
     {:ok, _} for success and {:error, :not_found} for failure.

<!--- List and detail all changes made in this PR. -->


## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

