### PR TITLE
update product state

### DIFF
--- a/apps/snitch_core/priv/repo/demo/products.ex
+++ b/apps/snitch_core/priv/repo/demo/products.ex
@@ -17,6 +17,7 @@ defmodule Snitch.Demo.Product do
   alias Snitch.Domain.Taxonomy
   alias Snitch.Tools.Helper.ImageUploader
   alias Snitch.Data.Model.Image, as: ImageModel
+  alias Snitch.Data.Model.Product, as: ProductModel
 
   @base_path Application.app_dir(:snitch_core, "priv/repo/demo/demo_data")
 
@@ -166,6 +167,7 @@ defmodule Snitch.Demo.Product do
     }
 
     product = %Product{} |> Product.create_changeset(params) |> Repo.insert!()
+    {:ok, product} = ProductModel.update(product, %{state: :active})
     associate_image(product, image, image_name)
   end
 


### PR DESCRIPTION
## Why?
To make the products in sample data with the active state by default. 
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
<!--- List and detail all changes made in this PR. -->
Updating the state to active after a product is created in sample data.

[delivers #163414904](https://www.pivotaltracker.com/story/show/163414904)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

