### PR TITLE
restricting deletion of option types

### DIFF
--- a/apps/admin_app/lib/admin_app_web/controllers/option_type_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/option_type_controller.ex
@@ -57,11 +57,17 @@ defmodule AdminAppWeb.OptionTypeController do
 
   def delete(conn, %{"id" => id}) do
     with {id, _} <- Integer.parse(id),
+         false <- OTModel.is_theme_associated(id),
          {:ok, option_type} <- OTModel.delete(id) do
       conn
       |> put_flash(:info, "Option type #{option_type.name} deleted successfully")
       |> redirect(to: option_type_path(conn, :index))
     else
+      true ->
+        conn
+        |> put_flash(:error, "Option type associated to variation theme. Deletion not allowed")
+        |> redirect(to: option_type_path(conn, :index))
+
       {:error, _} ->
         conn
         |> put_flash(:error, "Failed to delete option type")

--- a/apps/snitch_core/lib/core/data/model/option_type.ex
+++ b/apps/snitch_core/lib/core/data/model/option_type.ex
@@ -4,6 +4,9 @@ defmodule Snitch.Data.Model.OptionType do
   """
   use Snitch.Data.Model
   alias Snitch.Data.Schema.OptionType
+  alias Snitch.Data.Schema.Product
+  alias Snitch.Core.Tools.MultiTenancy.Repo
+  import Ecto.Query
 
   @doc """
   Create a OptionType with supplied params
@@ -50,5 +53,20 @@ defmodule Snitch.Data.Model.OptionType do
 
   def delete(%OptionType{} = instance) do
     QH.delete(OptionType, instance, Repo)
+  end
+
+  @doc """
+  Checks whether the OptionType is associated to any product's variation theme.
+  """
+  @spec is_theme_associated(non_neg_integer) :: true | false
+  def is_theme_associated(option_type_id) do
+    option_preloader = from(ot in OptionType, where: ot.id == ^option_type_id)
+
+    products =
+      from(p in Product, preload: [theme: [option_types: ^option_preloader]]) |> Repo.all()
+
+    Enum.any?(products, fn product ->
+      if product.theme != nil, do: length(product.theme.option_types) > 0
+    end)
   end
 end

--- a/apps/snitch_core/test/data/model/option_type_test.exs
+++ b/apps/snitch_core/test/data/model/option_type_test.exs
@@ -1,0 +1,50 @@
+defmodule Snitch.Data.Model.OptionTypeTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+
+  import Snitch.Factory
+
+  alias Snitch.Data.Model.OptionType, as: OTModel
+  alias Snitch.Data.Model.Product, as: ProductModel
+  alias Snitch.Data.Model.VariationTheme, as: VTModel
+  alias Snitch.Data.Schema.{Product, OptionType, VariationTheme}
+  alias Snitch.Repo
+
+  setup do
+    option_type = insert(:option_type)
+    shipping_category = insert(:shipping_category)
+
+    {:ok, theme} =
+      %{
+        "name" => "ThemeXYZ",
+        "option_type_ids" => [to_string(option_type.id)]
+      }
+      |> VTModel.create()
+
+    taxon = insert(:taxon)
+
+    params = %{
+      "name" => "ProductXYZ",
+      "selling_price" => Money.new("12.99", currency()),
+      "max_retail_price" => Money.new("14.99", currency()),
+      "taxon_id" => taxon.id,
+      "shipping_category_id" => shipping_category.id
+    }
+
+    {:ok, product} = ProductModel.create(params)
+    product = Product.associate_theme_changeset(product, %{theme_id: theme.id}) |> Repo.update!()
+
+    [option_type: option_type]
+  end
+
+  describe "option type association" do
+    test "if it's associated with a product's theme", %{option_type: option_type} do
+      assert OTModel.is_theme_associated(option_type.id) == true
+    end
+
+    test "if it's not associated with any product's theme" do
+      option_type = insert(:option_type)
+      assert OTModel.is_theme_associated(option_type.id) == false
+    end
+  end
+end


### PR DESCRIPTION
## Why?
To prevent the user from deleting option types which are associated with any product's variation theme.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
Adding a function in option_type model file to check if the option type is associated to any product's theme or not.
<!--- List and detail all changes made in this PR. -->


[delivers #162698336](https://www.pivotaltracker.com/story/show/162698336)
## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

