### PR TITLE
Adds TaxZones and TaxRates

### DIFF
--- a/apps/snitch_core/lib/core/data/model/tax/tax_rate.ex
+++ b/apps/snitch_core/lib/core/data/model/tax/tax_rate.ex
@@ -1,0 +1,84 @@
+defmodule Snitch.Data.Model.TaxRate do
+  @moduledoc """
+  Exposes APIs for tax rate CRUD.
+  """
+
+  use Snitch.Data.Model
+  alias Snitch.Data.Schema.TaxRate
+
+  @doc """
+  Creates a tax rate for the supplied params.
+
+  Expects the following keys in the `params`:
+  - `*name`: Name of the tax rate.
+  - `*tax_zone_id`: id of the tax zone for which tax rate would be created.
+  - `is_active?`: a boolean value which represents if the tax rate would be treated
+        as active or not, this is optional param and is set to true by default.
+  - `priority`: The priority in which the taxes would be calculated. To see further
+     details. See `Snitch.Data.Schema.TaxRate`.
+  - `*tax_rate_class_values`: A set of values to be set for different tax classes. The values
+      set are used to calculate the taxes for the order falling in the tax zone having the tax
+      rate.
+      The `tax_rate_class_values` is a map which expects the following keys:
+      - `*tax_rate_class_id`: The class for which value would be stored for the tax rate.
+      - `*percent_amount`: The amount to be stored for the `tax_class`.
+
+      The `tax_rate_class_values` are being handled using
+      `Ecto.Changeset.cast_assoc(changeset, name, opts \\ [])` with tax rate.
+
+  > The tax rate names are unique for every tax zone.
+  > Also, a tax rate can be associated with a class in the `tax_rate_class_values` table only once.
+  > `*` are required params.
+
+  """
+  @spec create(map) :: {:ok, TaxRate.t()} | {:error, Ecto.Changeset.t()}
+  def create(params) do
+    QH.create(TaxRate, params, Repo)
+  end
+
+  @doc """
+  Updates a `TaxRate` with the supplied `params`.
+
+  To know about the expected keys see `create/1`
+
+  > Since `:tax_rate_class_values` for a tax rate are updated with cast_assoc
+    rules added by `Ecto.Changeset.cast_assoc/3` are applied.
+  """
+  @spec update(TaxRate.t(), map) :: {:ok, TaxRate.t()} | {:error, Ecto.Changeset.t()}
+  def update(tax_rate, params) do
+    tax_rate = tax_rate |> Repo.preload(:tax_rate_class_values)
+    QH.update(TaxRate, params, tax_rate, Repo)
+  end
+
+  @doc """
+  Deletes a TaxRate.
+  """
+  def delete(id) do
+    QH.delete(TaxRate, id, Repo)
+  end
+
+  @doc """
+  Returns a tax rate preloaded with it's values corresponding to
+  tax classes under the key `:tax_rate_class_values`
+  """
+  def get(id) do
+    TaxRate
+    |> QH.get(id, Repo)
+    |> case do
+      {:ok, tax_rate} ->
+        {:ok, Repo.preload(tax_rate, :tax_rate_class_values)}
+
+      {:error, _} = error ->
+        error
+    end
+  end
+
+  @doc """
+  Returns a list of `TaxRates` preloaded with values for
+  tax class it is associated with.
+  """
+  @spec get_all() :: [TaxRate.t()]
+  def get_all() do
+    TaxRate |> Repo.all() |> Repo.preload(:tax_rate_class_values)
+  end
+end

--- a/apps/snitch_core/lib/core/data/model/tax/tax_zone.ex
+++ b/apps/snitch_core/lib/core/data/model/tax/tax_zone.ex
@@ -1,0 +1,48 @@
+defmodule Snitch.Data.Model.TaxZone do
+  @moduledoc """
+  Exposes API for tax zone.
+  """
+
+  use Snitch.Data.Model
+  alias Snitch.Data.Schema.TaxZone
+
+  @doc """
+  Creates a `tax_zone` with the supplied params.
+
+  Expected keys in params:
+  - `*name`: name of the tax zone.
+  - `is_active?`: whether the tax zone should be active or not.
+  - `*zone_id`: zone with which it would be associated.
+
+  > * are required fields.
+
+  >`Zones` with which a tax zone is associated as such have no restrictions on their
+    members while they are created. However, tax zones which can also be of type state
+    or country depending on the zone they are associated with, need to have members
+    mutually exclusive of each other. Also, two tax zones can not be associated with the
+    same zone.
+  """
+  @spec create(map) ::
+          {:ok, TaxZone.t()}
+          | {:error, Ecto.Changeset.t()}
+  def create(params) do
+    QH.create(TaxZone, params, Repo)
+  end
+
+  @spec update(TaxZone.t(), map) ::
+          {:ok, TaxZone.t()}
+          | {:error, Ecto.Changeset.t()}
+  def update(tax_zone, params) do
+    QH.update(TaxZone, params, tax_zone, Repo)
+  end
+
+  @spec get(non_neg_integer) :: {:ok, TaxZone.t()} | {:error, String.t()}
+  def get(id) do
+    QH.get(TaxZone, id, Repo)
+  end
+
+  @spec get_all() :: [TaxZone.t()]
+  def get_all() do
+    Repo.all(TaxZone)
+  end
+end

--- a/apps/snitch_core/lib/core/data/model/zone/zone.ex
+++ b/apps/snitch_core/lib/core/data/model/zone/zone.ex
@@ -145,11 +145,16 @@ defmodule Snitch.Data.Model.Zone do
   end
 
   @spec get(map | non_neg_integer) :: Zone.t() | nil
-  def get(id) do
+  def get(id) when is_integer(id) do
     Zone
     |> where([z], z.id == ^id)
     |> Repo.all()
     |> List.first()
+  end
+
+  def get(id) when is_binary(id) do
+    id = String.to_integer(id)
+    get(id)
   end
 
   def get_all() do

--- a/apps/snitch_core/lib/core/data/schema/tax/tax_rate.ex
+++ b/apps/snitch_core/lib/core/data/schema/tax/tax_rate.ex
@@ -1,0 +1,76 @@
+defmodule Snitch.Data.Schema.TaxRate do
+  @moduledoc """
+  Models a TaxRate.
+
+  TaxRate belongs to a zone.
+  A tax rate basically groups the tax values for different tax classes. These are used
+  for tax calculation.
+  ### e.g.
+  ```
+    `ProductTaxClass`: 5%,
+    `ShippingTaxClass`: 2%
+  ```
+  A tax rate has a priority associated with it. While calculating taxes for a `tax_zone` the tax
+  rates with lowest priority are calculated first.
+  After this the taxes are compounded upon the one created with lower priority.
+  ### Example
+    ```
+      tax_rate_1: %{priority: 0, rate: 2%},
+      tax_rate_2: %{priority: 0, rate: 3%},
+      tax_rate_3: %{priority: 1, rate: 1%}
+
+      base_amount = 10
+      level_1_amount = 10 * 0.02 + 10 * 0.01 + 10
+      total_amount = 0.01 * level_1_amount
+    ```
+    Here first taxes due to tax_rate_1 and tax_rate_2 are calculated on the base amount which
+    are added together to give a level_1_amount. The tax_rate_3 is then applied on this to give
+    total amount.
+  """
+
+  use Snitch.Data.Schema
+  alias Snitch.Data.Schema.{TaxZone, TaxRateClassValue}
+
+  @type t :: %__MODULE__{}
+
+  schema "snitch_tax_rates" do
+    field(:name, :string)
+    field(:priority, :integer, default: 0)
+    field(:is_active?, :boolean, default: true)
+
+    belongs_to(:tax_zone, TaxZone)
+    has_many(:tax_rate_class_values, TaxRateClassValue, on_replace: :delete)
+
+    timestamps()
+  end
+
+  @required ~w(name tax_zone_id)a
+  @optional ~w(is_active? priority)a
+  @permitted @required ++ @optional
+
+  def create_changeset(%__MODULE__{} = tax_rate, params) do
+    tax_rate
+    |> cast(params, @permitted)
+    |> common_changeset()
+  end
+
+  def update_changeset(%__MODULE__{} = tax_rate, params) do
+    tax_rate
+    |> cast(params, @permitted)
+    |> common_changeset()
+  end
+
+  defp common_changeset(changeset) do
+    changeset
+    |> validate_required(@required)
+    |> foreign_key_constraint(:tax_zone_id)
+    |> unique_constraint(:name,
+      name: :unique_tax_rate_name_for_tax_zone,
+      message: "Tax Rate name should be unique for a tax zone."
+    )
+    |> cast_assoc(:tax_rate_class_values,
+      with: &TaxRateClassValue.changeset/2,
+      required: true
+    )
+  end
+end

--- a/apps/snitch_core/lib/core/data/schema/tax/tax_rate_class_value.ex
+++ b/apps/snitch_core/lib/core/data/schema/tax/tax_rate_class_value.ex
@@ -1,0 +1,32 @@
+defmodule Snitch.Data.Schema.TaxRateClassValue do
+  @moduledoc """
+  Models a TaxRateClassValue
+
+  The TaxRateClassValue model is repsonsible for handling the percent amount to
+  be used for a tax rate while calculating taxes.
+  """
+
+  use Snitch.Data.Schema
+  alias Snitch.Data.Schema.{TaxRate, TaxClass}
+
+  schema "snitch_tax_rate_class_values" do
+    field(:percent_amount, :integer, default: 0)
+
+    belongs_to(:tax_class, TaxClass)
+    belongs_to(:tax_rate, TaxRate, on_replace: :delete)
+
+    timestamps()
+  end
+
+  @permitted ~w(tax_class_id tax_rate_id percent_amount)a
+
+  def changeset(%__MODULE__{} = data, params) do
+    data
+    |> cast(params, @permitted)
+    |> validate_required([:tax_class_id, :percent_amount])
+    |> validate_number(:percent_amount, greater_than_or_equal_to: 0)
+    |> foreign_key_constraint(:tax_rate_id)
+    |> foreign_key_constraint(:tax_class_id)
+    |> unique_constraint(:tax_rate_id, name: :unique_tax_rate_class_value)
+  end
+end

--- a/apps/snitch_core/lib/core/data/schema/tax/tax_zone.ex
+++ b/apps/snitch_core/lib/core/data/schema/tax/tax_zone.ex
@@ -1,0 +1,152 @@
+defmodule Snitch.Data.Schema.TaxZone do
+  @moduledoc """
+  Models a Tax Zone.
+
+  Tax zone plays an important role in tax calculation.
+  The `address` for which tax needs to be calculated is evaluated against the
+  tax zone which best encompasses the address.
+
+  > The address depends on the type of address set under `calculation_address_type`
+  in tax_configuration table. See `Snitch.Data.Schema.TaxConfig`
+
+  A zone has multiple tax rates which are then used to calculate the tax for the
+  order.
+  """
+
+  use Snitch.Data.Schema
+  import Ecto.Query
+  alias Snitch.Data.Schema.{Zone, CountryZoneMember, StateZoneMember, TaxZone, TaxRate}
+  alias Snitch.Data.Model.Zone, as: ZoneModel
+
+  @typedoc """
+  - `name`: tax zone name.
+  - `is_active?`: checks if the tax zone is active.
+  - `zone`: zone with which the tax is associated.
+
+  > `Zones` as such have no restrictions on their members while they are created.
+  > However, tax zones which can also be of type of state or country depending on the zone
+  > they are associated with needs to have members mutually exclusive of each other.
+  > Also, two tax zones can be associate with the same zone.
+  """
+
+  @type t :: %__MODULE__{}
+
+  @exculsivity %{
+    success: "Tax Zone mutually exclusive of others",
+    failure_state: "Tax Zone with one or more states in zone already present",
+    failure_country: "Tax Zone with one or more countries in zone already present"
+  }
+
+  schema "snitch_tax_zones" do
+    field(:name, :string)
+    field(:is_active?, :boolean, default: true)
+
+    belongs_to(:zone, Zone, on_replace: :raise)
+    has_many(:tax_rates, TaxRate)
+
+    timestamps()
+  end
+
+  @required ~w(name zone_id)a
+  @optional ~w(is_active?)a
+  @permitted @required ++ @optional
+
+  def create_changeset(%__MODULE__{} = tax_zone, params) do
+    tax_zone
+    |> cast(params, @permitted)
+    |> common_changeset()
+  end
+
+  def update_changeset(%__MODULE__{} = tax_zone, params) do
+    tax_zone
+    |> cast(params, @permitted)
+    |> common_changeset()
+  end
+
+  def common_changeset(changeset) do
+    changeset
+    |> validate_required(@required)
+    |> unique_constraint(:name)
+    |> foreign_key_constraint(:zone_id)
+    |> unique_constraint(:zone_id,
+      name: :unique_zone_for_tax,
+      message: "tax zone exists with supplied zone"
+    )
+    |> tax_zone_exclusivity()
+  end
+
+  # Runs a check for mutual exclusivity with other tax zones so that, no two tax zone have common
+  # members(country, state depending on the zone type).
+  defp tax_zone_exclusivity(%Ecto.Changeset{valid?: true} = changeset) do
+    with {:ok, zone_id} <- fetch_change(changeset, :zone_id),
+         zone when not is_nil(zone) <- ZoneModel.get(zone_id),
+         {:ok, _} <- verify_exclusivity(zone, zone.zone_type) do
+      changeset
+    else
+      {:error, message} ->
+        add_error(changeset, :zone_id, message)
+
+      :error ->
+        changeset
+
+      nil ->
+        add_error(changeset, :zone_id, "does not exist")
+    end
+  end
+
+  defp tax_zone_exclusivity(%Ecto.Changeset{valid?: false} = changeset), do: changeset
+
+  defp verify_exclusivity(zone, "S") do
+    zone_members_set = zone_members_set(zone)
+    tax_zone_state_set = tax_zone_set(:state)
+
+    case MapSet.disjoint?(zone_members_set, tax_zone_state_set) do
+      true ->
+        {:ok, @exculsivity.success}
+
+      false ->
+        {:error, @exculsivity.failure_state}
+    end
+  end
+
+  defp verify_exclusivity(zone, "C") do
+    zone_members_set = zone_members_set(zone)
+    tax_zone_country_set = tax_zone_set(:country)
+
+    case MapSet.disjoint?(zone_members_set, tax_zone_country_set) do
+      true ->
+        {:ok, @exculsivity.success}
+
+      false ->
+        {:error, @exculsivity.failure_country}
+    end
+  end
+
+  defp zone_members_set(zone) do
+    zone
+    |> ZoneModel.members()
+    |> MapSet.new(fn member -> member.id end)
+  end
+
+  defp tax_zone_set(:state) do
+    (tz in TaxZone)
+    |> from(
+      join: s_z_member in StateZoneMember,
+      on: tz.zone_id == s_z_member.zone_id,
+      select: s_z_member.state_id
+    )
+    |> Repo.all()
+    |> MapSet.new()
+  end
+
+  defp tax_zone_set(:country) do
+    (tz in TaxZone)
+    |> from(
+      join: c_z_member in CountryZoneMember,
+      on: tz.zone_id == c_z_member.zone_id,
+      select: c_z_member.country_id
+    )
+    |> Repo.all()
+    |> MapSet.new()
+  end
+end

--- a/apps/snitch_core/priv/repo/migrations/20190126101434_add_tax_zone_and_rate.exs
+++ b/apps/snitch_core/priv/repo/migrations/20190126101434_add_tax_zone_and_rate.exs
@@ -1,0 +1,42 @@
+defmodule Snitch.Repo.Migrations.AddTaxZone do
+  use Ecto.Migration
+
+  def change do
+    create table(:snitch_tax_zones) do
+      add(:name, :string, nil: false)
+      add(:is_active?, :boolean, default: true)
+      add(:zone_id, references("snitch_zones", on_delete: :restrict), nil: false)
+
+      timestamps()
+    end
+
+    create unique_index(:snitch_tax_zones, [:name])
+    create unique_index(:snitch_tax_zones, [:zone_id], name: :unique_zone_for_tax)
+
+    drop table(:snitch_tax_rates)
+
+    create table(:snitch_tax_rates) do
+      add(:name, :string, null: false)
+      add(:priority, :integer, default: 0)
+      add(:is_active?, :boolean, default: true)
+
+      add(:tax_zone_id, references(:snitch_tax_zones, on_delete: :delete_all), null: false)
+
+      timestamps()
+    end
+
+    create unique_index(:snitch_tax_rates, [:name, :tax_zone_id],
+      name: :unique_tax_rate_name_for_tax_zone)
+
+    create table(:snitch_tax_rate_class_values) do
+      add(:percent_amount, :integer, null: false)
+      add(:tax_rate_id, references(:snitch_tax_rates, on_delete: :delete_all), null: false)
+      add(:tax_class_id, references(:snitch_tax_classes, on_delete: :delete_all), null: false)
+
+      timestamps()
+    end
+
+    create unique_index(:snitch_tax_rate_class_values, [:tax_rate_id, :tax_class_id],
+      name: :unique_tax_rate_class_value)
+  end
+end

--- a/apps/snitch_core/test/data/model/tax/tax_rate_test.exs
+++ b/apps/snitch_core/test/data/model/tax/tax_rate_test.exs
@@ -1,0 +1,146 @@
+defmodule Snitch.Data.Model.TaxRateTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+  import Snitch.Factory
+  alias Snitch.Data.Model.TaxRate
+
+  describe "create/1" do
+    test "successfully" do
+      tax_class_1 = insert(:tax_class)
+      tax_class_2 = insert(:tax_class)
+
+      tax_class_values = [
+        %{tax_class_id: tax_class_1.id, percent_amount: 2},
+        %{tax_class_id: tax_class_2.id, percent_amount: 3}
+      ]
+
+      tax_zone = setup_tax_zone()
+
+      params = %{name: "GST", tax_rate_class_values: tax_class_values, tax_zone_id: tax_zone.id}
+      assert {:ok, _data} = TaxRate.create(params)
+    end
+
+    test "fails if tax rate exists with same name for the same tax zone" do
+      tax_zone = setup_tax_zone()
+
+      tax_rate =
+        :tax_rate
+        |> insert(tax_zone: tax_zone)
+        |> Repo.preload(:tax_rate_class_values)
+
+      tax_class_1 = insert(:tax_class)
+      tax_class_2 = insert(:tax_class)
+
+      tax_class_values = [
+        %{tax_class_id: tax_class_1.id, percent_amount: 2},
+        %{tax_class_id: tax_class_2.id, percent_amount: 3}
+      ]
+
+      params = %{
+        name: tax_rate.name,
+        tax_rate_class_values: tax_class_values,
+        tax_zone_id: tax_zone.id
+      }
+
+      assert {:error, changeset} = TaxRate.create(params)
+
+      assert %{
+               name: ["Tax Rate name should be unique for a tax zone."]
+             } == errors_on(changeset)
+    end
+  end
+
+  describe "update/2" do
+    test "success" do
+      tax_zone = setup_tax_zone()
+      tax_rate = :tax_rate |> insert(tax_zone: tax_zone) |> Repo.preload(:tax_rate_class_values)
+      assert tax_rate.tax_rate_class_values == []
+
+      tax_class_1 = insert(:tax_class)
+      tax_class_2 = insert(:tax_class)
+
+      tax_class_values = [
+        %{tax_class_id: tax_class_1.id, percent_amount: 2},
+        %{tax_class_id: tax_class_2.id, percent_amount: 3}
+      ]
+
+      params = %{tax_rate_class_values: tax_class_values}
+
+      assert {:ok, updated_tax_rate} = TaxRate.update(tax_rate, params)
+      assert updated_tax_rate.tax_rate_class_values != []
+    end
+
+    test "fails if any error on changeset" do
+      tax_zone = setup_tax_zone()
+      tax_rate = :tax_rate |> insert(tax_zone: tax_zone) |> Repo.preload(:tax_rate_class_values)
+      assert tax_rate.tax_rate_class_values == []
+
+      tax_class = insert(:tax_class)
+      # Deliberately set same tax_class id for two tax_class_values.
+      tax_class_values = [
+        %{tax_class_id: tax_class.id, percent_amount: 2},
+        %{tax_class_id: tax_class.id, percent_amount: 3}
+      ]
+
+      params = %{tax_rate_class_values: tax_class_values}
+
+      assert {:error, changeset} = TaxRate.update(tax_rate, params)
+
+      assert %{
+               tax_rate_class_values: [%{}, %{tax_rate_id: ["has already been taken"]}]
+             } == errors_on(changeset)
+    end
+  end
+
+  test "delete success" do
+    tax_zone = setup_tax_zone()
+    tax_class_1 = insert(:tax_class)
+    tax_class_2 = insert(:tax_class)
+
+    tax_class_values = [
+      %{tax_class_id: tax_class_1.id, percent_amount: 2},
+      %{tax_class_id: tax_class_2.id, percent_amount: 3}
+    ]
+
+    params = %{name: "GST", tax_zone_id: tax_zone.id, tax_rate_class_values: tax_class_values}
+    assert {:ok, tax_rate} = TaxRate.create(params)
+
+    assert {:ok, _data} = TaxRate.delete(tax_rate.id)
+  end
+
+  describe "get/1" do
+    test "returns for valid id" do
+      tax_zone = setup_tax_zone()
+      tax_rate = insert(:tax_rate, tax_zone: tax_zone)
+
+      assert {:ok, _tax_rate} = TaxRate.get(tax_rate.id)
+    end
+
+    test "returns error if invalid id" do
+      assert {:error, message} = TaxRate.get(-1)
+      assert message == :tax_rate_not_found
+    end
+  end
+
+  test "get_all returns a list of tax rates" do
+    tax_zone = setup_tax_zone()
+    tax_rate_1 = insert(:tax_rate, tax_zone: tax_zone)
+    tax_rate_2 = insert(:tax_rate, tax_zone: tax_zone)
+
+    tax_rates = TaxRate.get_all()
+    assert length(tax_rates) == 2
+  end
+
+  def setup_tax_zone() do
+    zone = insert(:zone, zone_type: "C")
+    [countries: countries] = countries(%{state_count: 3})
+    setup_country_zone_members(zone, countries)
+    insert(:tax_zone, zone: zone)
+  end
+
+  defp setup_country_zone_members(zone, countries) do
+    Enum.each(countries, fn country ->
+      insert(:country_zone_member, zone: zone, country: country)
+    end)
+  end
+end

--- a/apps/snitch_core/test/data/model/tax/tax_zone_test.exs
+++ b/apps/snitch_core/test/data/model/tax/tax_zone_test.exs
@@ -1,0 +1,178 @@
+defmodule Snitch.Data.Model.TaxZoneTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+  import Snitch.Factory
+  alias Snitch.Data.Model.TaxZone
+
+  @exculsivity %{
+    success: "Tax Zone mutually exclusive of others",
+    failure_state: "Tax Zone with one or more states in zone already present",
+    failure_country: "Tax Zone with one or more countries in zone already present"
+  }
+
+  setup :states
+  setup :countries
+
+  describe "create/1" do
+    @tag state_count: 3
+    test "fails if selected zone is not mutually exclusive, type state", context do
+      zone_1 = insert(:zone, zone_type: "S")
+      %{states: states} = context
+      setup_state_zone_members(zone_1, states)
+      [state_1, _, _] = states
+      insert(:tax_zone, zone: zone_1)
+
+      zone_2 = insert(:zone, zone_type: "S")
+      [states: new_states] = states(%{state_count: 2})
+      setup_state_zone_members(zone_2, [state_1 | new_states])
+
+      params = %{name: "APACzone", zone_id: zone_2.id}
+      assert {:error, changeset} = TaxZone.create(params)
+
+      assert %{
+               zone_id: ["Tax Zone with one or more states in zone already present"]
+             } == errors_on(changeset)
+    end
+
+    @tag state_count: 3
+    test "success if selected zone is mutually exclusive, type state", context do
+      zone_1 = insert(:zone, zone_type: "S")
+      %{states: states} = context
+      setup_state_zone_members(zone_1, states)
+      [state_1, _, _] = states
+      insert(:tax_zone, zone: zone_1)
+
+      zone_2 = insert(:zone, zone_type: "S")
+      [states: new_states] = states(%{state_count: 2})
+      setup_state_zone_members(zone_2, new_states)
+
+      params = %{name: "APACzone", zone_id: zone_2.id}
+      assert {:ok, _zone} = TaxZone.create(params)
+    end
+
+    @tag state_count: 3
+    test "fails for missing params", context do
+      params = %{}
+      assert {:error, changeset} = TaxZone.create(params)
+      assert %{name: ["can't be blank"], zone_id: ["can't be blank"]} == errors_on(changeset)
+    end
+
+    @tag country_count: 3
+    test "fails if selected zone is not mutually exclusive, type country", context do
+      zone_1 = insert(:zone, zone_type: "C")
+      %{countries: countries} = context
+      setup_country_zone_members(zone_1, countries)
+      [country_1, _, _] = countries
+      insert(:tax_zone, zone: zone_1)
+
+      zone_2 = insert(:zone, zone_type: "C")
+      [countries: new_countries] = countries(%{country_count: 2})
+      setup_country_zone_members(zone_2, [country_1 | new_countries])
+
+      params = %{name: "APACzone", zone_id: zone_2.id}
+      assert {:error, changeset} = TaxZone.create(params)
+
+      assert %{
+               zone_id: ["Tax Zone with one or more countries in zone already present"]
+             } == errors_on(changeset)
+    end
+
+    @tag country_count: 3
+    test "success if selected zone is mutually exclusive, type country", context do
+      zone_1 = insert(:zone, zone_type: "C")
+      %{countries: countries} = context
+      setup_country_zone_members(zone_1, countries)
+      [country_1, _, _] = countries
+      insert(:tax_zone, zone: zone_1)
+
+      zone_2 = insert(:zone, zone_type: "C")
+      [countries: new_countries] = countries(%{state_count: 2})
+      setup_country_zone_members(zone_2, new_countries)
+
+      params = %{name: "APACzone", zone_id: zone_2.id}
+      assert {:ok, _zone} = TaxZone.create(params)
+    end
+  end
+
+  describe "update/2" do
+    @tag country_count: 3
+    test "succcessfully", context do
+      zone = insert(:zone, zone_type: "C")
+      %{countries: countries} = context
+      setup_country_zone_members(zone, countries)
+      tax_zone = insert(:tax_zone, zone: zone)
+      params = %{name: "Pacific"}
+
+      {:ok, updated_zone} = TaxZone.update(tax_zone, params)
+      assert updated_zone.id == tax_zone.id
+      refute updated_zone.name == tax_zone.name
+    end
+
+    @tag country_count: 3
+    test "fails if zone set to one associated with another tax zone", context do
+      zone_1 = insert(:zone, zone_type: "C")
+      %{countries: countries} = context
+      setup_country_zone_members(zone_1, countries)
+      insert(:tax_zone, zone: zone_1)
+
+      zone_2 = insert(:zone, zone_type: "C")
+      [countries: new_countries] = countries(%{state_count: 3})
+      setup_country_zone_members(zone_2, new_countries)
+      tax_zone = insert(:tax_zone, zone: zone_2)
+
+      params = %{name: "Pacific", zone_id: zone_1.id}
+
+      assert {:error, changeset} = TaxZone.update(tax_zone, params)
+
+      assert %{
+               zone_id: ["Tax Zone with one or more countries in zone already present"]
+             } == errors_on(changeset)
+    end
+  end
+
+  describe "get/1" do
+    @tag country_count: 3
+    test "success", context do
+      zone = insert(:zone, zone_type: "C")
+      %{countries: countries} = context
+      setup_country_zone_members(zone, countries)
+      tax_zone = insert(:tax_zone, zone: zone)
+
+      assert {:ok, _country} = TaxZone.get(tax_zone.id)
+    end
+
+    test "returns error if not found", context do
+      zone = insert(:zone, zone_type: "C")
+      %{countries: countries} = context
+      setup_country_zone_members(zone, countries)
+      tax_zone = insert(:tax_zone, zone: zone)
+
+      assert {:error, message} = TaxZone.get(-1)
+      assert message == :tax_zone_not_found
+    end
+  end
+
+  describe "get_all" do
+    @tag country_count: 3
+    test "returns a list", context do
+      zone = insert(:zone, zone_type: "C")
+      %{countries: countries} = context
+      setup_country_zone_members(zone, countries)
+      tax_zone = insert(:tax_zone, zone: zone)
+
+      assert [_] = TaxZone.get_all()
+    end
+  end
+
+  defp setup_state_zone_members(zone, states) do
+    Enum.each(states, fn state ->
+      insert(:state_zone_member, zone: zone, state: state)
+    end)
+  end
+
+  defp setup_country_zone_members(zone, countries) do
+    Enum.each(countries, fn country ->
+      insert(:country_zone_member, zone: zone, country: country)
+    end)
+  end
+end

--- a/apps/snitch_core/test/data/schema/tax/tax_rate_test.exs
+++ b/apps/snitch_core/test/data/schema/tax/tax_rate_test.exs
@@ -1,0 +1,85 @@
+defmodule Snitch.Data.Schema.TaxRateTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+  import Snitch.Factory
+  alias Snitch.Data.Schema.TaxRate
+
+  describe "create_changeset/2" do
+    test "returns invalid changeset for missing params" do
+      params = %{}
+      changeset = TaxRate.create_changeset(%TaxRate{}, params)
+      refute changeset.valid?
+
+      assert %{
+               name: ["can't be blank"],
+               tax_rate_class_values: ["can't be blank"],
+               tax_zone_id: ["can't be blank"]
+             } == errors_on(changeset)
+    end
+
+    test "return valid changeset" do
+      tax_class_1 = insert(:tax_class)
+      tax_class_2 = insert(:tax_class)
+
+      tax_class_values = [
+        %{tax_class_id: tax_class_1.id, percent_amount: 2},
+        %{tax_class_id: tax_class_2.id, percent_amount: 3}
+      ]
+
+      tax_zone = setup_tax_zone()
+
+      params = %{name: "GST", tax_rate_class_values: tax_class_values, tax_zone_id: tax_zone.id}
+      changeset = TaxRate.create_changeset(%TaxRate{}, params)
+      assert changeset.valid?
+    end
+
+    test "fails for invalid tax-zone id" do
+      tax_class_1 = insert(:tax_class)
+      tax_class_2 = insert(:tax_class)
+
+      tax_class_values = [
+        %{tax_class_id: tax_class_1.id, percent_amount: 2},
+        %{tax_class_id: tax_class_2.id, percent_amount: 3}
+      ]
+
+      params = %{name: "GST", tax_rate_class_values: tax_class_values, tax_zone_id: -1}
+
+      changeset = TaxRate.create_changeset(%TaxRate{}, params)
+      assert {:error, changeset} = Repo.insert(changeset)
+      assert %{tax_zone_id: ["does not exist"]} = errors_on(changeset)
+    end
+  end
+
+  describe "update_changeset/2" do
+    test "returns a valid changeset" do
+      tax_zone = setup_tax_zone()
+      tax_rate = :tax_rate |> insert(tax_zone: tax_zone) |> Repo.preload(:tax_rate_class_values)
+
+      tax_class_1 = insert(:tax_class)
+      tax_class_2 = insert(:tax_class)
+
+      tax_class_values = [
+        %{tax_class_id: tax_class_1.id, percent_amount: 2},
+        %{tax_class_id: tax_class_2.id, percent_amount: 3}
+      ]
+
+      params = %{tax_rate_class_values: tax_class_values}
+
+      changeset = TaxRate.update_changeset(tax_rate, params)
+      assert changeset.valid?
+    end
+  end
+
+  def setup_tax_zone() do
+    zone = insert(:zone, zone_type: "C")
+    [countries: countries] = countries(%{state_count: 3})
+    setup_country_zone_members(zone, countries)
+    insert(:tax_zone, zone: zone)
+  end
+
+  defp setup_country_zone_members(zone, countries) do
+    Enum.each(countries, fn country ->
+      insert(:country_zone_member, zone: zone, country: country)
+    end)
+  end
+end

--- a/apps/snitch_core/test/data/schema/tax/tax_zone_test.exs
+++ b/apps/snitch_core/test/data/schema/tax/tax_zone_test.exs
@@ -1,0 +1,42 @@
+defmodule Snitch.Data.Schema.TaxZoneTest do
+  use ExUnit.Case, async: true
+  use Snitch.DataCase
+  import Snitch.Factory
+  alias Snitch.Data.Schema.TaxZone
+
+  describe "create_changeset/2" do
+    test "fails for missing params" do
+      params = %{}
+      changeset = TaxZone.create_changeset(%TaxZone{}, params)
+
+      assert %{name: ["can't be blank"], zone_id: ["can't be blank"]} == errors_on(changeset)
+    end
+
+    test "fails with invalid zone_id" do
+      params = %{zone_id: -1, name: "India"}
+      changeset = TaxZone.create_changeset(%TaxZone{}, params)
+
+      assert {:error, changeset} = Repo.insert(changeset)
+      assert %{zone_id: ["does not exist"]} == errors_on(changeset)
+    end
+
+    test "fails for unique constraitnts" do
+      zone = insert(:zone, zone_type: "S")
+      tax_zone = insert(:tax_zone, zone: zone)
+
+      params = %{name: "AAPCTax", zone_id: zone.id}
+      changeset = TaxZone.create_changeset(%TaxZone{}, params)
+
+      {:error, changeset} = Repo.insert(changeset)
+      assert %{zone_id: ["tax zone exists with supplied zone"]} == errors_on(changeset)
+
+      zone_new = insert(:zone, zone_type: "C")
+      params = %{name: tax_zone.name, zone_id: zone_new.id}
+      changeset = TaxZone.create_changeset(%TaxZone{}, params)
+
+      {:error, changeset} = Repo.insert(changeset)
+
+      assert %{name: ["has already been taken"]} == errors_on(changeset)
+    end
+  end
+end

--- a/apps/snitch_core/test/support/factory/tax.ex
+++ b/apps/snitch_core/test/support/factory/tax.ex
@@ -5,7 +5,9 @@ defmodule Snitch.Factory.Tax do
     quote do
       alias Snitch.Data.Schema.{
         TaxClass,
-        TaxConfig
+        TaxConfig,
+        TaxZone,
+        TaxRate
       }
 
       def tax_class_factory() do
@@ -25,6 +27,23 @@ defmodule Snitch.Factory.Tax do
           gift_tax: build(:tax_class),
           default_country: build(:country),
           default_state: build(:state)
+        }
+      end
+
+      def tax_zone_factory() do
+        %TaxZone{
+          name: sequence(:tax_zone_name, fn id -> "taxzone_#{id}" end),
+          is_active?: false,
+          zone: build(:zone)
+        }
+      end
+
+      def tax_rate_factory() do
+        %TaxRate{
+          name: sequence(:tax_rate_name, fn id -> "taxrate_#{id}" end),
+          tax_zone: build(:tax_zone),
+          is_active?: true,
+          priority: 0
         }
       end
     end

--- a/apps/snitch_core/test/support/factory/zone.ex
+++ b/apps/snitch_core/test/support/factory/zone.ex
@@ -3,12 +3,26 @@ defmodule Snitch.Factory.Zone do
 
   defmacro __using__(_opts) do
     quote do
-      alias Snitch.Data.Schema.{CountryZone, StateZone, Zone}
+      alias Snitch.Data.Schema.{CountryZone, StateZone, Zone, StateZoneMember, CountryZoneMember}
 
       def zone_factory do
         %Zone{
           name: sequence(:area, fn area_code -> "area-#{area_code + 51}" end),
           description: "Does area-51 exist?"
+        }
+      end
+
+      def state_zone_member_factory do
+        %StateZoneMember{
+          zone: build(:zone, zone_type: "S"),
+          state: build(:state)
+        }
+      end
+
+      def country_zone_member_factory do
+        %CountryZoneMember{
+          zone: build(:zone, zone_type: "S"),
+          country: build(:country)
         }
       end
 


### PR DESCRIPTION
Tax Rates and Tax Zones

## Why?
Adds tax zones and tax rates modeling along with CRUD functionality for both. Tax zones and tax rates allow the admin to set tax percentages which would be used while calculating tax for an order falling in that particular zone. Tax Rates set percent amount for different tax class created by the admin and store values for them.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
<!--- List and detail all changes made in this PR. -->

This change
- Add schema and model for Tax Rates and Zones.
- Add migration to create tax rate, tax zone and tax rate class values
  to handle the functionality.


[delivers #163283432]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read [CONTRIBUTING.md][contributing].
- [x] My code follows the [style guidelines][contributing] of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [x] I have updated the documentation wherever necessary.
- [x] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

