### PR TITLE
Test for CountryZoneMember and StateZoneMember (model/schema)

### DIFF
--- a/apps/snitch_core/test/data/model/zone/country_zone_test.exs
+++ b/apps/snitch_core/test/data/model/zone/country_zone_test.exs
@@ -3,9 +3,8 @@ defmodule Snitch.Data.Model.CountryZoneTest do
   use Snitch.DataCase
 
   import Snitch.Factory
-  import Ecto.Query
-  alias Ecto.Query
 
+  alias Ecto.Query
   alias Snitch.Data.Model.CountryZone
   alias Snitch.Data.Schema.{CountryZoneMember, Zone}
 

--- a/apps/snitch_core/test/data/model/zone/country_zone_test.exs
+++ b/apps/snitch_core/test/data/model/zone/country_zone_test.exs
@@ -88,8 +88,7 @@ defmodule Snitch.Data.Model.CountryZoneTest do
     end
 
     test "fails for invalid id", %{zone: zone} do
-      {:ok, _} = CountryZone.delete(zone)
-      assert CountryZone.get(zone.id) == {:error, :zone_not_found}
+      assert {:error, :zone_not_found} = CountryZone.get(-1)
     end
   end
 

--- a/apps/snitch_core/test/data/model/zone/country_zone_test.exs
+++ b/apps/snitch_core/test/data/model/zone/country_zone_test.exs
@@ -82,66 +82,82 @@ defmodule Snitch.Data.Model.CountryZoneTest do
   end
 
   describe "get/1" do
-    test "zone with id", %{zone: zone} do
+    test "returns a zone using a zone_id", %{zone: zone} do
       {:ok, new_zone} = CountryZone.get(zone.id)
       assert new_zone.id == zone.id
+    end
+
+    test "fails for invalid id", %{zone: zone} do
+      {:ok, _} = CountryZone.delete(zone)
+      assert CountryZone.get(zone.id) == {:error, :zone_not_found}
     end
   end
 
   describe "get_all/0" do
-    @tag state_zone_count: 3,
-         country_zone_count: 3
-    test "zones  successfully", %{zones: zone} do
+    @tag country_zone_count: 3
+    test "returns all zones", %{zones: zone} do
       country_zones = CountryZone.get_all()
-      cz = Enum.drop_while(country_zones, fn x -> x.zone_type == "C" end)
-      assert cz == []
+      country_zones = Enum.all?(country_zones, fn x -> x.zone_type == "C" end)
+      assert country_zones
+    end
+
+    @tag state_zone_count: 3
+    test "fails when no country_zone is present", %{zones: zone} do
+      country_zones = CountryZone.get_all()
+      cz_list = List.delete_at(country_zones, 0)
+      country_zones = Enum.any?(cz_list, fn x -> x.zone_type == "C" end)
+      refute country_zones
     end
   end
 
   describe "member_changesets/2" do
-    test "successfully returns a CountryZoneMember changeset", %{zone: zone, countries: countries} do
+    test "returns a valid changeset", %{zone: zone, countries: countries} do
       country_ids = Enum.map(countries, &Map.get(&1, :id))
       stream = CountryZone.member_changesets(country_ids, zone)
       changeset = Enum.find_value(stream, fn x -> x end)
       assert changeset.valid?
     end
-  end
 
-  describe "remove_members_query/2" do
-    @tag country_zone_count: 3
-    test "returns a query successfully", %{zone: zone, countries: countries} do
+    test "fails to return a valid changeset", %{zone: zone, countries: countries} do
       country_ids = Enum.map(countries, &Map.get(&1, :id))
-
-      expected =
-        Query.from(c in CountryZoneMember,
-          where: c.country_id in ^country_ids and c.zone_id == ^zone.id
-        )
-
-      result = CountryZone.remove_members_query(country_ids, zone)
-
-      assert inspect(result) == inspect(expected)
+      zone = Map.put(zone, :id, nil)
+      stream = CountryZone.member_changesets(country_ids, zone)
+      changeset = Enum.find_value(stream, fn x -> x end)
+      refute changeset.valid?
+      assert %{zone_id: ["can't be blank"]} == errors_on(changeset)
     end
   end
 
-  describe "common_zone_query/2" do
-    @tag country_count: 2
-    test "returns a query successfully", %{countries: countries} do
-      [country_a_id, country_b_id] = Enum.map(countries, fn x -> x.id end)
+  test "remove_members_query/2 returns a valid query", %{zone: zone, countries: countries} do
+    country_ids = Enum.map(countries, &Map.get(&1, :id))
 
-      expected =
-        Query.from(c0 in CountryZoneMember,
-          join: c1 in CountryZoneMember,
-          on: true,
-          join: z in Zone,
-          on: c0.zone_id == c1.zone_id and c0.zone_id == z.id,
-          where: c0.country_id == ^country_a_id and c1.country_id == ^country_b_id,
-          select: z
-        )
+    expected =
+      Query.from(c in CountryZoneMember,
+        where: c.country_id in ^country_ids and c.zone_id == ^zone.id
+      )
 
-      result = CountryZone.common_zone_query(country_a_id, country_b_id)
+    result = CountryZone.remove_members_query(country_ids, zone)
 
-      assert inspect(result) == inspect(expected)
-    end
+    assert inspect(result) == inspect(expected)
+  end
+
+  @tag country_count: 2
+  test "common_zone_query/2 returns a valid query", %{countries: countries} do
+    [country_a_id, country_b_id] = Enum.map(countries, fn x -> x.id end)
+
+    expected =
+      Query.from(c0 in CountryZoneMember,
+        join: c1 in CountryZoneMember,
+        on: true,
+        join: z in Zone,
+        on: c0.zone_id == c1.zone_id and c0.zone_id == z.id,
+        where: c0.country_id == ^country_a_id and c1.country_id == ^country_b_id,
+        select: z
+      )
+
+    result = CountryZone.common_zone_query(country_a_id, country_b_id)
+
+    assert inspect(result) == inspect(expected)
   end
 
   defp country_zone(%{countries: countries}) do

--- a/apps/snitch_core/test/data/model/zone/state_zone_test.exs
+++ b/apps/snitch_core/test/data/model/zone/state_zone_test.exs
@@ -89,66 +89,82 @@ defmodule Snitch.Data.Model.StateZoneTest do
   end
 
   describe "get/1" do
-    test "zone with id", %{zone: zone} do
+    test "returns a state_zone using a zone_id", %{zone: zone} do
       {:ok, new_zone} = StateZone.get(zone.id)
       assert new_zone.id == zone.id
+    end
+
+    test "fails for invalid id", %{zone: zone} do
+      {:ok, _} = StateZone.delete(zone)
+      assert StateZone.get(zone.id) == {:error, :zone_not_found}
     end
   end
 
   describe "get_all/0" do
-    @tag state_zone_count: 3,
-         country_zone_count: 3
-    test "zones  successfully", %{zones: zone} do
+    @tag state_zone_count: 3
+    test "returns all state_zones", %{zones: zone} do
       state_zones = StateZone.get_all()
-      sz = Enum.drop_while(state_zones, fn x -> x.zone_type == "S" end)
-      assert sz == []
+      state_zones = Enum.all?(state_zones, fn x -> x.zone_type == "S" end)
+      assert state_zones
+    end
+
+    @tag country_zone_count: 3
+    test "fails when no state_zone is present", %{zones: zone} do
+      state_zones = StateZone.get_all()
+      sz_list = List.delete_at(state_zones, 0)
+      state_zones = Enum.any?(sz_list, fn x -> x.zone_type == "S" end)
+      refute state_zones
     end
   end
 
   describe "member_changesets/2" do
-    test "successfully returns a CountryZoneMember changeset", %{zone: zone, states: states} do
+    test "returns a valid changeset", %{zone: zone, states: states} do
       state_ids = Enum.map(states, &Map.get(&1, :id))
       stream = StateZone.member_changesets(state_ids, zone)
       changeset = Enum.find_value(stream, fn x -> x end)
       assert changeset.valid?
     end
-  end
 
-  describe "remove_members_query/2" do
-    @tag state_zone_count: 3
-    test "returns a query successfully", %{zone: zone, states: states} do
+    test "fails to return a valid changeset", %{zone: zone, states: states} do
       state_ids = Enum.map(states, &Map.get(&1, :id))
-
-      expected =
-        Query.from(c in StateZoneMember,
-          where: c.state_id in ^state_ids and c.zone_id == ^zone.id
-        )
-
-      result = StateZone.remove_members_query(state_ids, zone)
-
-      assert inspect(result) == inspect(expected)
+      zone = Map.put(zone, :id, nil)
+      stream = StateZone.member_changesets(state_ids, zone)
+      changeset = Enum.find_value(stream, fn x -> x end)
+      refute changeset.valid?
+      assert %{zone_id: ["can't be blank"]} == errors_on(changeset)
     end
   end
 
-  describe "common_zone_query/2" do
-    @tag state_count: 2
-    test "returns a query successfully", %{states: states} do
-      [state_a_id, state_b_id] = Enum.map(states, fn x -> x.id end)
+  test "remove_members_query/2 returns a valid query", %{zone: zone, states: states} do
+    state_ids = Enum.map(states, &Map.get(&1, :id))
 
-      expected =
-        Query.from(c0 in StateZoneMember,
-          join: c1 in StateZoneMember,
-          on: true,
-          join: z in Zone,
-          on: c0.zone_id == c1.zone_id and c0.zone_id == z.id,
-          where: c0.state_id == ^state_a_id and c1.state_id == ^state_b_id,
-          select: z
-        )
+    expected =
+      Query.from(c in StateZoneMember,
+        where: c.state_id in ^state_ids and c.zone_id == ^zone.id
+      )
 
-      result = StateZone.common_zone_query(state_a_id, state_b_id)
+    result = StateZone.remove_members_query(state_ids, zone)
 
-      assert inspect(result) == inspect(expected)
-    end
+    assert inspect(result) == inspect(expected)
+  end
+
+  @tag state_count: 2
+  test "common_zone_query/2 returns a valid query", %{states: states} do
+    [state_a_id, state_b_id] = Enum.map(states, fn x -> x.id end)
+
+    expected =
+      Query.from(c0 in StateZoneMember,
+        join: c1 in StateZoneMember,
+        on: true,
+        join: z in Zone,
+        on: c0.zone_id == c1.zone_id and c0.zone_id == z.id,
+        where: c0.state_id == ^state_a_id and c1.state_id == ^state_b_id,
+        select: z
+      )
+
+    result = StateZone.common_zone_query(state_a_id, state_b_id)
+
+    assert inspect(result) == inspect(expected)
   end
 
   defp state_zone(%{states: states}) do

--- a/apps/snitch_core/test/data/model/zone/state_zone_test.exs
+++ b/apps/snitch_core/test/data/model/zone/state_zone_test.exs
@@ -95,8 +95,7 @@ defmodule Snitch.Data.Model.StateZoneTest do
     end
 
     test "fails for invalid id", %{zone: zone} do
-      {:ok, _} = StateZone.delete(zone)
-      assert StateZone.get(zone.id) == {:error, :zone_not_found}
+      {:error, :zone_not_found} = StateZone.get(-1)
     end
   end
 

--- a/apps/snitch_core/test/data/model/zone/state_zone_test.exs
+++ b/apps/snitch_core/test/data/model/zone/state_zone_test.exs
@@ -3,7 +3,6 @@ defmodule Snitch.Data.Model.StateZoneTest do
   use Snitch.DataCase
 
   import Snitch.Factory
-  import Ecto.Query
 
   alias Ecto.Query
   alias Snitch.Data.Model.StateZone

--- a/apps/snitch_core/test/data/schema/zone/country_zone_member_test.exs
+++ b/apps/snitch_core/test/data/schema/zone/country_zone_member_test.exs
@@ -74,7 +74,7 @@ defmodule Snitch.Data.Schema.CountryZoneMemberTest do
       ]
     end
 
-    test "successfully for valid params", %{cs: cs} do
+    test "returns a valid changeset", %{cs: cs} do
       params = %{country_id: 200}
       changeset = CountryZoneMember.update_changeset(cs, params)
       assert changeset.valid?

--- a/apps/snitch_core/test/data/schema/zone/country_zone_member_test.exs
+++ b/apps/snitch_core/test/data/schema/zone/country_zone_member_test.exs
@@ -8,6 +8,21 @@ defmodule Snitch.Data.Schema.CountryZoneMemberTest do
 
   setup :countries
 
+  describe "create_changeset/2" do
+    test "successfully for valid params", %{countries: [country]} do
+      zone = insert(:zone, zone_type: "C")
+      params = %{zone_id: zone.id, country_id: country.id}
+      cs = CountryZoneMember.create_changeset(%CountryZoneMember{}, params)
+      assert cs.valid?
+    end
+
+    test "fails for invalid params" do
+      params = %{zone_id: nil, country_id: nil}
+      cs = CountryZoneMember.create_changeset(%CountryZoneMember{}, params)
+      assert %{zone_id: ["can't be blank"], country_id: ["can't be blank"]} == errors_on(cs)
+    end
+  end
+
   describe "CountryZoneMember records" do
     test "refer only country type zones", %{countries: [country]} do
       country_zone = insert(:zone, zone_type: "C")
@@ -42,6 +57,41 @@ defmodule Snitch.Data.Schema.CountryZoneMemberTest do
 
       assert {:ok, _} = Repo.insert(czm_changset)
       assert {:error, cs} = Repo.insert(czm_changset)
+      assert %{country_id: ["has already been taken"]} = errors_on(cs)
+    end
+  end
+
+  describe "update_changeset/2" do
+    setup %{countries: [country]} do
+      zone = insert(:zone, zone_type: "C")
+      params = %{zone_id: zone.id, country_id: country.id}
+
+      [
+        cs:
+          %CountryZoneMember{}
+          |> CountryZoneMember.create_changeset(params)
+          |> apply_changes()
+      ]
+    end
+
+    test "successfully for valid params", %{cs: cs} do
+      params = %{country_id: 200}
+      changeset = CountryZoneMember.update_changeset(cs, params)
+      assert changeset.valid?
+    end
+
+    test "fails for invalid params", %{cs: cs} do
+      params = %{country_id: -1}
+      changeset = CountryZoneMember.update_changeset(cs, params)
+      {:error, changeset} = Repo.insert(changeset)
+      assert %{country_id: ["does not exist"]} == errors_on(changeset)
+    end
+
+    test "fails for duplicate country_id", %{cs: cs} do
+      Repo.insert(cs)
+      params = %{country_id: cs.country_id}
+      changeset = CountryZoneMember.update_changeset(cs, params)
+      {:error, cs} = Repo.insert(changeset)
       assert %{country_id: ["has already been taken"]} = errors_on(cs)
     end
   end

--- a/apps/snitch_core/test/data/schema/zone/state_zone_member_test.exs
+++ b/apps/snitch_core/test/data/schema/zone/state_zone_member_test.exs
@@ -8,6 +8,20 @@ defmodule Snitch.Data.Schema.StateZoneMemberTest do
 
   setup :states
 
+  describe "create_changeset/2" do
+    test "successfully for valid params", %{states: [state]} do
+      zone = insert(:zone, zone_type: "S")
+      params = %{zone_id: zone.id, state_id: state.id}
+      cs = StateZoneMember.create_changeset(%StateZoneMember{}, params)
+      assert cs.valid?
+    end
+
+    test "fails for invalid params" do
+      cs = StateZoneMember.create_changeset(%StateZoneMember{}, %{})
+      assert %{zone_id: ["can't be blank"], state_id: ["can't be blank"]} == errors_on(cs)
+    end
+  end
+
   describe "StateZoneMember records" do
     test "refer only state type zones", %{states: [state]} do
       state_zone = insert(:zone, zone_type: "S")
@@ -42,6 +56,41 @@ defmodule Snitch.Data.Schema.StateZoneMemberTest do
 
       assert {:ok, _} = Repo.insert(szm_changset)
       assert {:error, cs} = Repo.insert(szm_changset)
+      assert %{state_id: ["has already been taken"]} = errors_on(cs)
+    end
+  end
+
+  describe "update_changeset/2" do
+    setup %{states: [state]} do
+      zone = insert(:zone, zone_type: "S")
+      params = %{zone_id: zone.id, state_id: state.id}
+
+      [
+        cs:
+          %StateZoneMember{}
+          |> StateZoneMember.create_changeset(params)
+          |> apply_changes()
+      ]
+    end
+
+    test "successfully for valid params", %{cs: cs} do
+      params = %{state_id: 200}
+      changeset = StateZoneMember.update_changeset(cs, params)
+      assert changeset.valid?
+    end
+
+    test "fails for invalid params", %{cs: cs} do
+      params = %{state_id: -1}
+      changeset = StateZoneMember.update_changeset(cs, params)
+      {:error, changeset} = Repo.insert(changeset)
+      assert %{state_id: ["does not exist"]} == errors_on(changeset)
+    end
+
+    test "fails for duplicate country_id", %{cs: cs} do
+      Repo.insert(cs)
+      params = %{state_id: cs.state_id}
+      changeset = StateZoneMember.update_changeset(cs, params)
+      {:error, cs} = Repo.insert(changeset)
       assert %{state_id: ["has already been taken"]} = errors_on(cs)
     end
   end

--- a/apps/snitch_core/test/data/schema/zone/state_zone_member_test.exs
+++ b/apps/snitch_core/test/data/schema/zone/state_zone_member_test.exs
@@ -73,7 +73,7 @@ defmodule Snitch.Data.Schema.StateZoneMemberTest do
       ]
     end
 
-    test "successfully for valid params", %{cs: cs} do
+    test "returns a valid changeset", %{cs: cs} do
       params = %{state_id: 200}
       changeset = StateZoneMember.update_changeset(cs, params)
       assert changeset.valid?


### PR DESCRIPTION
## Why?
  - Test cases were less for country and state zone member(model/schema)
  - Coverage was less for country and state zone member(model/schema)

## This change addresses the need by:
 - Wrote new test cases for update_changset in the schema for both country zone
   and state zone member.(Schema)
 - Wrote test cases for get/1, get_all/0, member_changesets/2,
   remove_members_query/2, common_zone_query/2 for both country and
   state zone member.(Model)

[delivers #163514116]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

