### PR TITLE
[bug] fix cachex key tenant based

### DIFF
--- a/apps/snitch_api/lib/snitch_api_web/controllers/product_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/product_controller.ex
@@ -42,7 +42,7 @@ defmodule SnitchApiWeb.ProductController do
   def index(conn, params) do
     {products, page, aggregations, total} =
       Cache.get(
-        current_url(conn),
+        conn.host <> conn.request_path <> conn.query_string,
         {
           fn conn, params -> Context.list_products(conn, params) end,
           [conn, params]
@@ -83,7 +83,7 @@ defmodule SnitchApiWeb.ProductController do
   def suggest(conn, %{"q" => term}) do
     suggestions =
       Cache.get(
-        current_url(conn),
+        conn.host <> conn.request_path <> conn.query_string,
         {
           fn term -> Context.suggest(term) end,
           [term]

--- a/apps/snitch_api/lib/snitch_api_web/controllers/taxonomy_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/taxonomy_controller.ex
@@ -14,7 +14,7 @@ defmodule SnitchApiWeb.TaxonomyController do
   def index(conn, _params) do
     taxonomy =
       Cache.get(
-        current_url(conn),
+        conn.host <> conn.request_path,
         {
           fn -> TaxonomyDomain.get_all_taxonomy() end,
           []


### PR DESCRIPTION
## Why?
Product search and Taxonomies result that were cached were not returning based on tenant.

## This change addresses the need by:
Fixes the Cache key based on tenant.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

