### PR TITLE
Add UI for Tax Zone and Tax Rates

### DIFF
--- a/apps/admin_app/lib/admin_app_web/controllers/tax/tax_rate_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/tax/tax_rate_controller.ex
@@ -1,0 +1,96 @@
+defmodule AdminAppWeb.Tax.TaxRateController do
+  use AdminAppWeb, :controller
+  alias Snitch.Data.Model.{TaxRate, TaxClass}
+  alias Snitch.Data.Schema.TaxRate, as: TaxRateSchema
+  alias Snitch.Data.Schema.TaxRateClassValue
+
+  plug(:put_layout, {AdminAppWeb.Tax.TaxZoneView, "tax_zone_layout.html"} when action in [:index])
+
+  def index(conn, %{"tax_zone_id" => tax_zone_id}) do
+    tax_rates = TaxRate.get_all_by_tax_zone(tax_zone_id)
+    render(conn, "index.html", tax_rates: tax_rates, tax_zone_id: tax_zone_id)
+  end
+
+  def new(conn, %{"tax_zone_id" => tax_zone_id}) do
+    changeset =
+      TaxRateSchema.create_changeset(
+        %TaxRateSchema{tax_rate_class_values: rate_values_struct()},
+        %{}
+      )
+
+    render(conn, "new.html", changeset: changeset, tax_zone_id: tax_zone_id)
+  end
+
+  def create(conn, %{"tax_rate" => params, "tax_zone_id" => tax_zone_id}) do
+    with {:ok, _tax_rate} <- TaxRate.create(params) do
+      redirect(conn, to: tax_zone_tax_rate_path(conn, :index, tax_zone_id))
+    else
+      {:error, changeset} ->
+        render(conn, "new.html",
+          changeset: %{changeset | action: :insert},
+          tax_zone_id: tax_zone_id
+        )
+    end
+  end
+
+  def edit(conn, %{"id" => id, "tax_zone_id" => tax_zone_id}) do
+    with {:ok, tax_rate} <- TaxRate.get(id) do
+      changeset = TaxRateSchema.update_changeset(tax_rate, %{})
+
+      render(conn, "edit.html", changeset: changeset, tax_rate: tax_rate, tax_zone_id: tax_zone_id)
+    else
+      {:error, _} ->
+        conn
+        |> put_flash(:error, "tax zone not found")
+
+        redirect(conn, to: tax_zone_tax_rate_path(conn, :index, tax_zone_id))
+    end
+  end
+
+  def update(conn, %{"id" => id, "tax_zone_id" => tax_zone_id, "tax_rate" => params}) do
+    tax_rate = id |> TaxRate.get() |> get(conn)
+
+    with {:ok, _config} <- TaxRate.update(tax_rate, params) do
+      redirect(conn, to: tax_zone_tax_rate_path(conn, :index, tax_zone_id))
+    else
+      {:error, changeset} ->
+        render(conn, "edit.html",
+          changeset: %{changeset | action: :update},
+          tax_rate: tax_rate,
+          tax_zone_id: tax_zone_id
+        )
+    end
+  end
+
+  def delete(conn, %{"id" => id, "tax_zone_id" => tax_zone_id}) do
+    with {:ok, _data} <- id |> String.to_integer() |> TaxRate.delete() do
+      conn
+      |> put_flash(:info, "tax zone deleted")
+      |> redirect(to: tax_zone_tax_rate_path(conn, :index, tax_zone_id))
+    else
+      {:error, message} ->
+        conn
+        |> put_flash(:error, message)
+        |> redirect(to: tax_zone_tax_rate_path(conn, :index, tax_zone_id))
+    end
+  end
+
+  defp rate_values_struct() do
+    tax_classes = TaxClass.get_all()
+
+    Enum.map(tax_classes, fn class ->
+      %TaxRateClassValue{
+        tax_class_id: class.id,
+        tax_class: class
+      }
+    end)
+  end
+
+  defp get({:ok, config}, _conn), do: config
+
+  defp get({:error, message}, conn) do
+    conn
+    |> put_flash(:error, message)
+    |> redirect(to: tax_zone_path(conn, :index))
+  end
+end

--- a/apps/admin_app/lib/admin_app_web/controllers/tax/tax_zone_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/tax/tax_zone_controller.ex
@@ -1,0 +1,89 @@
+defmodule AdminAppWeb.Tax.TaxZoneController do
+  @moduledoc false
+  use AdminAppWeb, :controller
+  alias Snitch.Data.Model.TaxZone
+  alias Snitch.Data.Schema.TaxZone, as: TaxZoneSchema
+
+  @default_layout_actions ~w(index new)a
+
+  plug(
+    :put_layout,
+    {AdminAppWeb.Tax.TaxConfigView, "tax_layout.html"} when action in @default_layout_actions
+  )
+
+  plug(
+    :put_layout,
+    {AdminAppWeb.Tax.TaxZoneView, "tax_zone_layout.html"}
+    when action not in @default_layout_actions
+  )
+
+  def index(conn, _params) do
+    tax_zones = TaxZone.get_all()
+    render(conn, "index.html", tax_zones: tax_zones)
+  end
+
+  def new(conn, _params) do
+    changeset = TaxZoneSchema.create_changeset(%TaxZoneSchema{}, %{})
+    render(conn, "new.html", changeset: changeset)
+  end
+
+  def create(conn, %{"tax_zone" => params}) do
+    with {:ok, tax_zone} <- TaxZone.create(params) do
+      redirect(conn, to: tax_zone_path(conn, :edit, tax_zone.id))
+    else
+      {:error, changeset} ->
+        conn
+        |> put_flash(:error, "There were some errors!")
+
+        render(conn, "new.html", changeset: %{changeset | action: :insert})
+    end
+  end
+
+  def edit(conn, %{"id" => id}) do
+    with {:ok, tax_zone} <- TaxZone.get(id) do
+      changeset = TaxZoneSchema.update_changeset(tax_zone, %{})
+      render(conn, "edit.html", changeset: changeset, tax_zone: tax_zone)
+    else
+      {:error, _} ->
+        conn
+        |> put_flash(:error, "tax zone not found")
+
+        redirect(conn, to: tax_zone_path(conn, :index))
+    end
+  end
+
+  def update(conn, %{"id" => id, "tax_zone" => params}) do
+    tax_zone = id |> TaxZone.get() |> get(conn)
+
+    with {:ok, _config} <- TaxZone.update(tax_zone, params) do
+      redirect(conn, to: tax_zone_path(conn, :index))
+    else
+      {:error, changeset} ->
+        render(conn, "edit.html",
+          changeset: %{changeset | action: :update},
+          tax_zone: tax_zone
+        )
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    with {:ok, _data} <- id |> String.to_integer() |> TaxZone.delete() do
+      conn
+      |> put_flash(:info, "tax zone deleted")
+      |> redirect(to: tax_zone_path(conn, :index))
+    else
+      {:error, message} ->
+        conn
+        |> put_flash(:error, message)
+        |> redirect(to: tax_zone_path(conn, :index))
+    end
+  end
+
+  defp get({:ok, config}, _conn), do: config
+
+  defp get({:error, message}, conn) do
+    conn
+    |> put_flash(:error, message)
+    |> redirect(to: tax_zone_path(conn, :index))
+  end
+end

--- a/apps/admin_app/lib/admin_app_web/router.ex
+++ b/apps/admin_app/lib/admin_app_web/router.ex
@@ -133,6 +133,10 @@ defmodule AdminAppWeb.Router do
     post("/tax/tax-classes/new", Tax.TaxClassController, :create)
     put("/tax/tax-classes/:id", Tax.TaxClassController, :update)
     delete("/tax/tax-classes/:id", Tax.TaxClassController, :delete)
+
+    resources("/tax/tax-zones", Tax.TaxZoneController, except: [:show]) do
+      resources("/tax-rates", Tax.TaxRateController, except: [:show])
+    end
   end
 
   scope "/", AdminAppWeb do

--- a/apps/admin_app/lib/admin_app_web/templates/tax/tax_config/tax_layout.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/tax/tax_config/tax_layout.html.eex
@@ -15,7 +15,7 @@
         </li>
         <li class="nav-item">
           <% route=("/tax/tax-zones") %>
-          <a class="nav-link <%= active_link(@conn, route) %>" href="/tax-zones">Tax Zones & Rates</a>
+          <a class="nav-link <%= active_link(@conn, route) %>" href="/tax/tax-zones">Tax Zones & Rates</a>
         </li>
       </ul>
       <div class="tab-content">

--- a/apps/admin_app/lib/admin_app_web/templates/tax/tax_rate/_form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/tax/tax_rate/_form.html.eex
@@ -1,0 +1,32 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <div class="form-group row ">
+    <%= input f, :name, nil, description: "Name of the Tax Rate. E.g. GST", is_horizontal: true %>
+  </div>
+  <div class="form-group row ">
+    <%= checkbox_input f, :is_active?, nil, 
+      description: "Toggle to change the status of tax rate as active or inactive.", is_horizontal: true %>
+  </div>
+  <%= hidden_input(f, :tax_zone_id, value: @tax_zone_id) %>
+  
+  <h5 class="m-1">Rates for Classes</h5>
+  <div class="container">
+    <%= inputs_for f, :tax_rate_class_values, fn p -> %>
+    <div class="form-group row">
+      <%= label p, :percent_amount, "#{p.data.tax_class.name} Percent Amount %", class: "col-sm-4 col-form-label" %>
+      <div class="col-md-1">
+        <%= text_input p, :percent_amount, class: "form-control" %>
+      </div>
+      <%= error_tag p, :percent_amount %>
+      <%= hidden_input(p, :tax_class_id, value: p.data.tax_class.id) %>
+    </div>
+    <% end %>
+  </div>
+
+  <div class="form-group row stickformbutton">
+    <div class="col-sm-10">
+      <%= button("Cancel", to: tax_zone_tax_rate_path(@conn, :index, @tax_zone_id), method: "get",
+              class: "btn submit-btn float-left", type: "button") %>
+      <%= submit "Submit", class: "btn btn-primary submit-btn float-right" %>
+    </div>
+  </div>
+<% end %>

--- a/apps/admin_app/lib/admin_app_web/templates/tax/tax_rate/edit.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/tax/tax_rate/edit.html.eex
@@ -1,0 +1,10 @@
+<div class="list-container">
+  <h4 class="p-3 m-0">Edit Tax Rate</h4> 
+  <div class="col-12">
+    <div class="card col-12">
+      <%= render "_form.html", changeset: @changeset, conn: @conn, 
+        tax_zone_id: @tax_zone_id,
+        action: tax_zone_tax_rate_path(@conn, :update, @tax_zone_id, @tax_rate)%>
+    </div>
+  </div>
+</div>

--- a/apps/admin_app/lib/admin_app_web/templates/tax/tax_rate/index.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/tax/tax_rate/index.html.eex
@@ -1,0 +1,48 @@
+<h4 class="p-3 m-0">Tax Rate</h4>
+<%= button("+ Add Tax Rate", to: tax_zone_tax_rate_path(@conn, :new, @tax_zone_id, []), method: "get", class: "btn btn-primary submit") %>
+<br><br>
+<ul class="list-group">
+</ul>
+
+<div class="list-container">
+   <div class="row m-0 list">
+     <%= for tax_rate <- @tax_rates do %>
+      <div class="table-contaner col-12 p-3 mb-2">
+         <div class="row">
+            <div class="col-11 pl-0">
+               <div class="media">
+                  <div class="checkbox mx-3">
+                     <label>
+                     <input type="checkbox" value="">
+                     <span class="cr"><i class="cr-icon fa fa-check"></i></span>
+                     </label>
+                  </div>
+                  <div class="media-body">
+                     <div class="row">
+                        <div class="col"> <%= tax_rate.name %> </div>
+                        <%= if tax_rate.is_active? do %>
+                          <div class="col"><kbd>Active</kbd></div>
+                        <% else %>
+                          <div class="col"></div>
+                        <% end %>
+                     </div>
+                  </div>
+               </div>
+            </div>
+            <div class="col-1">
+               <div class="dropdown col-12 p-0 float-right options-container">
+                  <a class="p-2 dropdown-toggle options" href="#" role="button"  data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <i class="fa fa-cog"></i>
+                  </a>
+                  <div class="dropdown-menu dropdown-menu-right" >
+                     <%= link("Edit", to: tax_zone_tax_rate_path(@conn, :edit, @tax_zone_id, tax_rate.id), class: "dropdown-item") %>
+                     <%= link("Delete", to: tax_zone_tax_rate_path(@conn, :delete, @tax_zone_id, tax_rate.id),
+                        method: :delete, data: [confirm: "Are you sure to delete"], class: "dropdown-item") %>
+                  </div>
+               </div>
+            </div>
+         </div>
+      </div>
+     <% end %>
+   </div>
+</div>

--- a/apps/admin_app/lib/admin_app_web/templates/tax/tax_rate/new.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/tax/tax_rate/new.html.eex
@@ -1,0 +1,10 @@
+<div class="list-container">
+  <h4 class="p-3 m-0">Add Tax Rate</h4> 
+  <div class="col-12">
+    <div class="card col-12">
+      <%= render "_form.html", changeset: @changeset, conn: @conn, 
+        tax_zone_id: @tax_zone_id,
+        action: tax_zone_tax_rate_path(@conn, :create, @tax_zone_id)%>
+    </div>
+  </div>
+</div>

--- a/apps/admin_app/lib/admin_app_web/templates/tax/tax_zone/_form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/tax/tax_zone/_form.html.eex
@@ -1,0 +1,25 @@
+<%= form_for @changeset, @action, fn f -> %>
+  <div class="form-group row ">
+    <%= input f, :name, nil, description: "Name of the Tax Zone. E.g. APAC", is_horizontal: true %>
+  </div>
+  <div class="form-group row ">
+    <%= select_input f, :zone_id, formatted_list(:zone), nil, 
+      description: "Select the zone with which this particular tax zone is associated. 
+        You can create new country or state zones from the zones configuration and select it here.", 
+        is_horizontal: true %>
+        <div class="col-sm-3">
+          <%= link "Add Zone", to: "/zones", class: "btn btn-outline-dark btn-sm" %>
+        </div>
+  </div>
+  <div class="form-group row ">
+    <%= checkbox_input f, :is_active?, nil, 
+      description: "Toggle to change the status of tax zone as active or inactive.", is_horizontal: true %>
+  </div>
+  <div class="form-group row stickformbutton">
+  <div class="col-sm-10">
+    <%= button("Cancel", to: tax_zone_path(@conn, :index), method: "get",
+            class: "btn submit-btn float-left", type: "button") %>
+    <%= submit "Submit", class: "btn btn-primary submit-btn float-right" %>
+  </div>
+  </div>
+<% end %>

--- a/apps/admin_app/lib/admin_app_web/templates/tax/tax_zone/edit.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/tax/tax_zone/edit.html.eex
@@ -1,0 +1,2 @@
+<%= render "_form.html", changeset: @changeset, conn: @conn,
+  action: tax_zone_path(@conn, :update, @tax_zone)%>

--- a/apps/admin_app/lib/admin_app_web/templates/tax/tax_zone/index.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/tax/tax_zone/index.html.eex
@@ -1,0 +1,49 @@
+<h4 class="p-3 m-0">Tax Zone</h4>
+<%= button("+ Add Tax Zone", to: tax_zone_path(@conn, :new), method: "get", class: "btn btn-primary submit") %>
+<br><br>
+<ul class="list-group">
+</ul>
+
+<div class="list-container">
+   <div class="row m-0 list">
+     <%= for tax_zone <- @tax_zones do %>
+      <div class="table-contaner col-12 p-3 mb-2">
+         <div class="row">
+            <div class="col-11 pl-0">
+               <div class="media">
+                  <div class="checkbox mx-3">
+                     <label>
+                     <input type="checkbox" value="">
+                     <span class="cr"><i class="cr-icon fa fa-check"></i></span>
+                     </label>
+                  </div>
+                  <div class="media-body">
+                     <div class="row">
+                        <div class="col"> <%= tax_zone.name %> </div>
+                        <div class="col"><%= zone_type(tax_zone) %></div>
+                        <%= if tax_zone.is_active? do %>
+                          <div class="col"><kbd>Active</kbd></div>
+                        <% else %>
+                          <div class="col"></div>
+                        <% end %>
+                     </div>
+                  </div>
+               </div>
+            </div>
+            <div class="col-1">
+               <div class="dropdown col-12 p-0 float-right options-container">
+                  <a class="p-2 dropdown-toggle options" href="#" role="button"  data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <i class="fa fa-cog"></i>
+                  </a>
+                  <div class="dropdown-menu dropdown-menu-right" >
+                     <%= link("Edit", to: tax_zone_path(@conn, :edit, tax_zone.id), class: "dropdown-item") %>
+                     <%= link("Delete", to: tax_zone_path(@conn, :delete, tax_zone.id),
+                        method: :delete, data: [confirm: "Are you sure to delete"], class: "dropdown-item") %>
+                  </div>
+               </div>
+            </div>
+         </div>
+      </div>
+     <% end %>
+   </div>
+</div>

--- a/apps/admin_app/lib/admin_app_web/templates/tax/tax_zone/new.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/tax/tax_zone/new.html.eex
@@ -1,0 +1,7 @@
+<div class="list-container">
+  <h4 class="p-3 m-0">Add Tax Zone</h4> 
+  <div class="col-12">
+    <%= render "_form.html", changeset: @changeset, conn: @conn,
+    action: tax_zone_path(@conn, :create)%>
+  </div>
+</div>

--- a/apps/admin_app/lib/admin_app_web/templates/tax/tax_zone/tax_zone_layout.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/tax/tax_zone/tax_zone_layout.html.eex
@@ -1,0 +1,23 @@
+
+<%= render_layout "app.html", assigns do %>
+<div class="list-container">
+  <h4 class="p-3 m-0">Tax Zone</h4>
+  <div class="col-12">
+    <div class="card col-12">
+      <ul class="nav nav-tabs">
+        <li class="nav-item">
+          <% route=("/tax/tax-zones/#{tax_zone_id(@conn)}/edit") %>
+          <a class="nav-link <%= active_link(@conn, route) %>" href="<%= route %>">Tax Zone Settings</a>   
+        </li>
+        <li class="nav-item">
+          <% route=("/tax/tax-zones/#{tax_zone_id(@conn)}/tax-rates")  %>
+          <a class="nav-link <%= active_link(@conn, route) %>" href="<%= route %>">Tax Rates</a>
+        </li>
+      </ul>
+      <div class="tab-content">
+        <%= render @view_module, @view_template, assigns %>
+      </div>
+    </div>
+  <div>
+</div>
+<% end %>

--- a/apps/admin_app/lib/admin_app_web/views/data_helpers.ex
+++ b/apps/admin_app/lib/admin_app_web/views/data_helpers.ex
@@ -8,6 +8,7 @@ defmodule AdminAppWeb.DataHelpers do
   alias Snitch.Data.Model.Role, as: RoleModel
   alias Snitch.Data.Model.TaxClass
   alias Snitch.Data.Model.Permission
+  alias Snitch.Data.Model.Zone
 
   @doc """
   Creates formatted data to be used in dropdown selection for association in forms.
@@ -20,5 +21,6 @@ defmodule AdminAppWeb.DataHelpers do
   def formatted_list(:role), do: RoleModel.formatted_list()
   def formatted_list(:permissions), do: Permission.formatted_list()
   def formatted_list(:tax_class), do: TaxClass.formatted_list()
+  def formatted_list(:zone), do: Zone.formatted_list()
   def formatted_list(country_id), do: StateModel.formatted_state_list(country_id)
 end

--- a/apps/admin_app/lib/admin_app_web/views/tax/tax_rate_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/tax/tax_rate_view.ex
@@ -1,0 +1,3 @@
+defmodule AdminAppWeb.Tax.TaxRateView do
+  use AdminAppWeb, :view
+end

--- a/apps/admin_app/lib/admin_app_web/views/tax/tax_zone_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/tax/tax_zone_view.ex
@@ -1,0 +1,25 @@
+defmodule AdminAppWeb.Tax.TaxZoneView do
+  use AdminAppWeb, :view
+  import AdminAppWeb.LayoutView, only: [render_layout: 3]
+  alias Snitch.Core.Tools.MultiTenancy.Repo
+
+  def active_link(conn, route) do
+    if conn.request_path == route do
+      "active"
+    else
+      ""
+    end
+  end
+
+  def tax_zone_id(conn) do
+    conn.params["id"] || conn.params["tax_zone_id"]
+  end
+
+  def zone_type(tax_zone) do
+    tax_zone = Repo.preload(tax_zone, :zone)
+    get_zone_type(tax_zone.zone.zone_type)
+  end
+
+  defp get_zone_type("S"), do: "State"
+  defp get_zone_type("C"), do: "Country"
+end

--- a/apps/snitch_core/lib/core/data/model/tax/tax_rate.ex
+++ b/apps/snitch_core/lib/core/data/model/tax/tax_rate.ex
@@ -46,7 +46,7 @@ defmodule Snitch.Data.Model.TaxRate do
   """
   @spec update(TaxRate.t(), map) :: {:ok, TaxRate.t()} | {:error, Ecto.Changeset.t()}
   def update(tax_rate, params) do
-    tax_rate = tax_rate |> Repo.preload(:tax_rate_class_values)
+    tax_rate = tax_rate |> Repo.preload(tax_rate_class_values: :tax_class)
     QH.update(TaxRate, params, tax_rate, Repo)
   end
 
@@ -66,7 +66,7 @@ defmodule Snitch.Data.Model.TaxRate do
     |> QH.get(id, Repo)
     |> case do
       {:ok, tax_rate} ->
-        {:ok, Repo.preload(tax_rate, :tax_rate_class_values)}
+        {:ok, Repo.preload(tax_rate, tax_rate_class_values: :tax_class)}
 
       {:error, _} = error ->
         error
@@ -80,5 +80,25 @@ defmodule Snitch.Data.Model.TaxRate do
   @spec get_all() :: [TaxRate.t()]
   def get_all() do
     TaxRate |> Repo.all() |> Repo.preload(:tax_rate_class_values)
+  end
+
+  @doc """
+  Returns all the tax rates for a `tax_zone`.
+  """
+  @spec get_all_by_tax_zone(non_neg_integer) :: [TaxRate.t()]
+  def get_all_by_tax_zone(tax_zone_id) do
+    query =
+      from(
+        tax_rate in TaxRate,
+        where: tax_rate.tax_zone_id == ^tax_zone_id,
+        select: %TaxRate{
+          name: tax_rate.name,
+          is_active?: tax_rate.is_active?,
+          priority: tax_rate.priority,
+          id: tax_rate.id
+        }
+      )
+
+    query |> Repo.all() |> Repo.preload(tax_rate_class_values: :tax_class)
   end
 end

--- a/apps/snitch_core/lib/core/data/model/tax/tax_zone.ex
+++ b/apps/snitch_core/lib/core/data/model/tax/tax_zone.ex
@@ -45,4 +45,11 @@ defmodule Snitch.Data.Model.TaxZone do
   def get_all() do
     Repo.all(TaxZone)
   end
+
+  @doc """
+  Deletes a TaxZone.
+  """
+  def delete(id) do
+    QH.delete(TaxZone, id, Repo)
+  end
 end

--- a/apps/snitch_core/lib/core/data/model/zone/zone.ex
+++ b/apps/snitch_core/lib/core/data/model/zone/zone.ex
@@ -162,4 +162,12 @@ defmodule Snitch.Data.Model.Zone do
     |> order_by([z], asc: z.name)
     |> Repo.all()
   end
+
+  @spec formatted_list() :: [{String.t(), non_neg_integer}]
+  def formatted_list do
+    Zone
+    |> order_by([s], asc: s.name)
+    |> select([s], {s.name, s.id})
+    |> Repo.all()
+  end
 end

--- a/apps/snitch_core/lib/core/data/schema/tax/tax_rate_class_value.ex
+++ b/apps/snitch_core/lib/core/data/schema/tax/tax_rate_class_value.ex
@@ -8,6 +8,7 @@ defmodule Snitch.Data.Schema.TaxRateClassValue do
 
   use Snitch.Data.Schema
   alias Snitch.Data.Schema.{TaxRate, TaxClass}
+  alias Snitch.Core.Tools.MultiTenancy.Repo
 
   schema "snitch_tax_rate_class_values" do
     field(:percent_amount, :integer, default: 0)
@@ -28,5 +29,21 @@ defmodule Snitch.Data.Schema.TaxRateClassValue do
     |> foreign_key_constraint(:tax_rate_id)
     |> foreign_key_constraint(:tax_class_id)
     |> unique_constraint(:tax_rate_id, name: :unique_tax_rate_class_value)
+    |> add_tax_class_data()
+  end
+
+  defp add_tax_class_data(changeset) do
+    with {:ok, tax_class_id} <- fetch_change(changeset, :tax_class_id) do
+      data = %{
+        changeset.data
+        | tax_class: Repo.get(TaxClass, tax_class_id),
+          tax_class_id: tax_class_id
+      }
+
+      %{changeset | data: data}
+    else
+      _ ->
+        changeset
+    end
   end
 end

--- a/apps/snitch_core/priv/repo/seed/seeds.exs
+++ b/apps/snitch_core/priv/repo/seed/seeds.exs
@@ -27,7 +27,8 @@ alias Snitch.Seed.{
   Product,
   StockLocation,
   ProductRating,
-  ShippingRules
+  ShippingRules,
+  Tax
 }
 
 alias Snitch.Tools.Helper.Taxonomy, as: TaxonomyHelper
@@ -77,3 +78,4 @@ StockLocation.seed!()
 ProductRating.seed()
 
 TaxonomyHelper.create_taxonomy({"Category", []})
+Tax.seed()

--- a/apps/snitch_core/test/data/model/tax/tax_rate_test.exs
+++ b/apps/snitch_core/test/data/model/tax/tax_rate_test.exs
@@ -124,11 +124,26 @@ defmodule Snitch.Data.Model.TaxRateTest do
 
   test "get_all returns a list of tax rates" do
     tax_zone = setup_tax_zone()
-    tax_rate_1 = insert(:tax_rate, tax_zone: tax_zone)
-    tax_rate_2 = insert(:tax_rate, tax_zone: tax_zone)
+    insert(:tax_rate, tax_zone: tax_zone)
+    insert(:tax_rate, tax_zone: tax_zone)
 
     tax_rates = TaxRate.get_all()
     assert length(tax_rates) == 2
+  end
+
+  describe "get_all_by_tax_zone/1" do
+    test "returns tax rates for given tax zone id" do
+      tax_zone_1 = setup_tax_zone()
+      insert(:tax_rate, tax_zone: tax_zone_1)
+
+      tax_zone_2 = setup_tax_zone()
+
+      assert data_1 = TaxRate.get_all_by_tax_zone(tax_zone_1.id)
+      assert length(data_1) == 1
+
+      assert data_2 = TaxRate.get_all_by_tax_zone(tax_zone_2.id)
+      assert data_2 == []
+    end
   end
 
   def setup_tax_zone() do

--- a/apps/snitch_core/test/data/model/tax/tax_zone_test.exs
+++ b/apps/snitch_core/test/data/model/tax/tax_zone_test.exs
@@ -164,6 +164,18 @@ defmodule Snitch.Data.Model.TaxZoneTest do
     end
   end
 
+  @tag country_count: 3
+  test "delete a tax zone", context do
+    zone = insert(:zone, zone_type: "C")
+    %{countries: countries} = context
+    setup_country_zone_members(zone, countries)
+    tax_zone = insert(:tax_zone, zone: zone)
+
+    assert {:ok, _data} = TaxZone.delete(tax_zone.id)
+    assert {:error, message} = TaxZone.get(tax_zone.id)
+    assert message == :tax_zone_not_found
+  end
+
   defp setup_state_zone_members(zone, states) do
     Enum.each(states, fn state ->
       insert(:state_zone_member, zone: zone, state: state)


### PR DESCRIPTION
## Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->
Admin should be able to create new tax zones from the admin panel and modify settings for the same. Also, the tax rates for a tax zone should be configurable from the admin panel.

## This change addresses the need by:
<!--- List and detail all changes made in this PR. -->
- Adds UI for tax zones.
- Adds UI to handle tax rates for a tax zone.
- Add/modify tax rate model to cater for new requirements.

__Comments__
- Makes extensive use of nested layouts to handle UI.
- In the `tax_rate_class_values` schema, I have to populate the changeset `data` with `tax_class` and 
`tax_class_id` if the changes contain `tax_class_id`. This was done because `tax_rate_class_values`  is being handled using `cast_assoc` in `tax_rate` schema and, these values are required to render the UI properly.

[delivers#163283477]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

