### PR TITLE
Add api scope to promotions API's

### DIFF
--- a/apps/admin_app/lib/admin_app_web/router.ex
+++ b/apps/admin_app/lib/admin_app_web/router.ex
@@ -128,16 +128,6 @@ defmodule AdminAppWeb.Router do
     get("/product/import/etsy/callback", ProductImportController, :oauth_callback)
     get("/product/import/etsy/progress", ProductImportController, :import_progress)
 
-    ### promotions
-    resources("/promotions", PromotionController, except: [:show, :new])
-    get("/promo-rules", PromotionController, :rules, as: :promo_rules)
-    get("/promo-actions", PromotionController, :actions, as: :promo_actions)
-    post("/promo-calculators", PromotionController, :calculators, as: :promo_calc)
-    post("/promo-rule-prefs", PromotionController, :rule_preferences, as: :promo_rule_prefs)
-    post("/promo-action-prefs", PromotionController, :action_preferences, as: :promo_action_prefs)
-    post("/promo-calc-prefs", PromotionController, :calc_preferences, as: :promo_calc_prefs)
-    put("/promo/:id/archive", PromotionController, :archive)
-
     ### tax
     get("/tax", Tax.TaxConfigController, :index)
     put("/tax/:id", Tax.TaxConfigController, :update)
@@ -151,6 +141,18 @@ defmodule AdminAppWeb.Router do
     resources("/tax/tax-zones", Tax.TaxZoneController, except: [:show]) do
       resources("/tax-rates", Tax.TaxRateController, except: [:show])
     end
+  end
+
+  scope "api/", AdminAppWeb do
+    ### promotions
+    resources("/promotions", PromotionController, except: [:show, :new])
+    get("/promo-rules", PromotionController, :rules, as: :promo_rules)
+    get("/promo-actions", PromotionController, :actions, as: :promo_actions)
+    post("/promo-calculators", PromotionController, :calculators, as: :promo_calc)
+    post("/promo-rule-prefs", PromotionController, :rule_preferences, as: :promo_rule_prefs)
+    post("/promo-action-prefs", PromotionController, :action_preferences, as: :promo_action_prefs)
+    post("/promo-calc-prefs", PromotionController, :calc_preferences, as: :promo_calc_prefs)
+    put("/promo/:id/archive", PromotionController, :archive)
   end
 
   scope "/", AdminAppWeb do


### PR DESCRIPTION
## Why?
Admin routes and the API routes will clash for promotion

## This change addresses the need by:
Moved promotion API's to api scope in admin app.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

