### PR TITLE
Add tax domain

### DIFF
--- a/apps/admin_app/lib/admin_app_web/controllers/product_controller.ex
+++ b/apps/admin_app/lib/admin_app_web/controllers/product_controller.ex
@@ -76,7 +76,7 @@ defmodule AdminAppWeb.ProductController do
 
     with {:ok, %ProductSchema{} = product} <- ProductModel.get(id) do
       product = product |> Repo.preload(preloads)
-      changeset = ProductSchema.create_changeset(product, params)
+      changeset = ProductSchema.update_changeset(product, params)
 
       rummage_params = RummageHelper.get_rummage_params(conn)
 

--- a/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/product/form.html.eex
@@ -84,8 +84,13 @@
       </div>
     </div>
       <div class="form-group row ">
-      <%= select_input f, :shipping_category_id, get_shipping_category(), nil, is_horizontal: true, description: "Select appropriate shipping method for the product eg. Heavy for Washing Machine, Light for T-shirt." %>
-    </div>
+        <%= select_input f, :shipping_category_id, get_shipping_category(), nil, is_horizontal: true, description: "Select appropriate shipping method for the product eg. Heavy for Washing Machine, Light for T-shirt." %>
+      </div>
+      <%= if tax_class_id_check(@changeset) do %>
+        <div class="form-group row ">
+          <%= select_input f, :tax_class_id, formatted_list(:tax_class), nil, is_horizontal: true, description: "Select the tax class this product belongs to. The tax for product would be calculated based on that." %>
+        </div>  
+      <% end %>
       <div class="form-group row ">
       <%= select_input f, :brand_id, get_brand_options(@brands), nil, is_horizontal: true, description: "Select branch of the product Eg. Levi's.", prompt: "Choose your brand" %>
     </div>

--- a/apps/admin_app/lib/admin_app_web/views/product_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/product_view.ex
@@ -28,6 +28,10 @@ defmodule AdminAppWeb.ProductView do
     Enum.map(StockLocation.active(), &{&1.name, &1.id})
   end
 
+  def tax_class_id_check(changeset) do
+    :tax_class_id in changeset.required
+  end
+
   def themes_options(product) do
     Enum.map(product.taxon.variation_themes, &{&1.name, &1.id})
   end

--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -551,10 +551,9 @@ defmodule Snitch.Data.Model.Product do
   end
 
   @doc """
-  Returns the parent product of the supplied variant.
+  Returns the `parent product` of the supplied `variant`.
 
-  In case supplied product is not a variant, an error tuple is
-  returned.
+  In case supplied product is not a variant, returns nil.
   """
   @spec get_parent_product(Product.t()) :: Product.t() | nil
   def get_parent_product(product) do
@@ -566,7 +565,7 @@ defmodule Snitch.Data.Model.Product do
   Returns `tax_class_id` of the product.
 
   Since tax class is set only for parent and not variants, if the
-  supplied product is variant, tax class for the parent product is
+  supplied product is a variant, tax class of the parent product is
   returned.
   """
   @spec get_tax_class_id(Product.t()) :: non_neg_integer

--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -549,4 +549,35 @@ defmodule Snitch.Data.Model.Product do
   defp get_product_with_upi(upi) do
     from(p in "snitch_products", select: p.upi, where: p.upi == ^upi) |> Repo.one()
   end
+
+  @doc """
+  Returns the parent product of the supplied variant.
+
+  In case supplied product is not a variant, an error tuple is
+  returned.
+  """
+  @spec get_parent_product(Product.t()) :: Product.t() | nil
+  def get_parent_product(product) do
+    product = Repo.preload(product, parent_variation: :parent_product)
+    if product.parent_variation, do: product.parent_variation.parent_product, else: nil
+  end
+
+  @doc """
+  Returns `tax_class_id` of the product.
+
+  Since tax class is set only for parent and not variants, if the
+  supplied product is variant, tax class for the parent product is
+  returned.
+  """
+  @spec get_tax_class_id(Product.t()) :: non_neg_integer
+  def get_tax_class_id(product) do
+    tax_class_id(product, product.tax_class_id)
+  end
+
+  defp tax_class_id(product, nil) do
+    product = get_parent_product(product)
+    product.tax_class_id
+  end
+
+  defp tax_class_id(_product, tax_class_id), do: tax_class_id
 end

--- a/apps/snitch_core/lib/core/data/schema/package_item.ex
+++ b/apps/snitch_core/lib/core/data/schema/package_item.ex
@@ -101,7 +101,7 @@ defmodule Snitch.Data.Schema.PackageItem do
 
   @create_fields ~w(state delta quantity line_item_id product_id package_id tax
     shipping_tax unit_price)a
-  @required_fields ~w(state quantity line_item_id product_id tax unit_price)a
+  @required_fields ~w(state quantity line_item_id product_id tax)a
   @update_fields ~w(state quantity delta tax shipping_tax unit_price)a
 
   @doc """

--- a/apps/snitch_core/lib/core/data/schema/package_item.ex
+++ b/apps/snitch_core/lib/core/data/schema/package_item.ex
@@ -63,7 +63,8 @@ defmodule Snitch.Data.Schema.PackageItem do
   The actual unit price for the package item. The `unit_price` may be same
   or different from the `line_item` unit price depending on whether, line
   item price is inclusive or exclusive of tax. In case line item price
-  is inclusive, this price is set after removing the tax amount form that.
+  is inclusive, this price is set after removing the tax amount from line_item
+  unit_price.
 
   ### `:tax`
   The tax levied over (or included in) the cost of the line item, as applicable

--- a/apps/snitch_core/lib/core/data/schema/package_item.ex
+++ b/apps/snitch_core/lib/core/data/schema/package_item.ex
@@ -59,10 +59,18 @@ defmodule Snitch.Data.Schema.PackageItem do
   The difference between the `:quantity` and the number of units "on
   hand".
 
+  ### `:unit_price`
+  The actual unit price for the package item. The `unit_price` may be same
+  or different from the `line_item` unit price depending on whether, line
+  item price is inclusive or exclusive of tax. In case line item price
+  is inclusive, this price is set after removing the tax amount form that.
+
   ### `:tax`
   The tax levied over (or included in) the cost of the line item, as applicable
-  when the line item is sold from the `:origin` stock location.
-  This does not include any shipping tax components.
+  when the line item is sold from the `:origin` stock location. The tax depends
+  on the type of shipping address set in `tax configuration`.
+  See `Snitch.Data.Schema.TaxConfig`. This does not include any shipping tax
+  components.
 
   ### `:shipping_tax`
   The sum of all shipping taxes that apply for the shipping of this item from
@@ -80,6 +88,7 @@ defmodule Snitch.Data.Schema.PackageItem do
     field(:backordered?, :boolean)
     field(:tax, Money.Ecto.Composite.Type)
     field(:shipping_tax, Money.Ecto.Composite.Type)
+    field(:unit_price, Money.Ecto.Composite.Type)
 
     belongs_to(:product, Product)
     belongs_to(:line_item, LineItem)
@@ -90,9 +99,10 @@ defmodule Snitch.Data.Schema.PackageItem do
     timestamps()
   end
 
-  @create_fields ~w(state delta quantity line_item_id product_id package_id tax shipping_tax)a
-  @required_fields ~w(state quantity line_item_id product_id tax)a
-  @update_fields ~w(state quantity delta tax shipping_tax)a
+  @create_fields ~w(state delta quantity line_item_id product_id package_id tax
+    shipping_tax unit_price)a
+  @required_fields ~w(state quantity line_item_id product_id tax unit_price)a
+  @update_fields ~w(state quantity delta tax shipping_tax unit_price)a
 
   @doc """
   Returns a `PackageItem` changeset to create a new `package_item`.
@@ -124,6 +134,7 @@ defmodule Snitch.Data.Schema.PackageItem do
     |> validate_number(:quantity, greater_than: -1)
     |> validate_number(:delta, greater_than: -1)
     |> validate_amount(:tax)
+    |> validate_amount(:unit_price)
     |> validate_amount(:shipping_tax)
     |> set_backordered()
   end

--- a/apps/snitch_core/lib/core/domain/order/transitions.ex
+++ b/apps/snitch_core/lib/core/domain/order/transitions.ex
@@ -198,7 +198,7 @@ defmodule Snitch.Domain.Order.Transitions do
         |> Stream.map(fn %{package_id: package_id, shipping_method_id: shipping_method_id} ->
           packages
           |> Enum.find(fn %{id: id} -> id == package_id end)
-          |> PackageDomain.set_shipping_method(shipping_method_id)
+          |> PackageDomain.set_shipping_method(shipping_method_id, order)
         end)
         |> fail_fast_reduce()
       end

--- a/apps/snitch_core/lib/core/domain/order/transitions.ex
+++ b/apps/snitch_core/lib/core/domain/order/transitions.ex
@@ -210,7 +210,7 @@ defmodule Snitch.Domain.Order.Transitions do
   end
 
   @doc """
-  Marks all the `shipment` aka `packages` of an ordertransition from `pending`
+  Marks all the `shipment` aka `packages` of an order transition from `pending`
   to the `processing` state.
 
   This function is a side effect of the transition in which payment for an

--- a/apps/snitch_core/lib/core/domain/package_item.ex
+++ b/apps/snitch_core/lib/core/domain/package_item.ex
@@ -5,6 +5,7 @@ defmodule Snitch.Domain.PackageItem do
 
   alias Snitch.Data.Schema.{PackageItem, StockLocation}
   alias Snitch.Tools.Money, as: MoneyTools
+  alias Snitch.Domain.Tax
 
   @spec tax(PackageItem.t(), StockLocation.t()) :: Money.t()
   def tax(_package_item, _stock_location) do
@@ -14,5 +15,13 @@ defmodule Snitch.Domain.PackageItem do
   @spec shipping_tax(PackageItem.t(), StockLocation.t()) :: Money.t()
   def shipping_tax(_package_item, _stock_location) do
     MoneyTools.zero!()
+  end
+
+  @doc """
+  Returns the unit price and tax for a package item in the following
+  format %{unit_price: data, tax: data}
+  """
+  def unit_price_with_tax(lineitem, order, stock_location) do
+    Tax.calculate(:package_item, lineitem, order, stock_location)
   end
 end

--- a/apps/snitch_core/lib/core/domain/package_item.ex
+++ b/apps/snitch_core/lib/core/domain/package_item.ex
@@ -19,7 +19,7 @@ defmodule Snitch.Domain.PackageItem do
 
   @doc """
   Returns the unit price and tax for a package item in the following
-  format %{unit_price: data, tax: data}
+  format %{original_amount: price, tax: tax_value}
   """
   def unit_price_with_tax(lineitem, order, stock_location) do
     Tax.calculate(:package_item, lineitem, order, stock_location)

--- a/apps/snitch_core/lib/core/domain/shipment.ex
+++ b/apps/snitch_core/lib/core/domain/shipment.ex
@@ -171,7 +171,14 @@ defmodule Snitch.Domain.Shipment do
 
     items =
       Enum.map(package.items, fn %{line_item: li, variant: v} = item ->
+        %{
+          original_amount: unit_price,
+          tax: tax
+        } = PackageItem.unit_price_with_tax(li, order, package.origin)
+
         item
+        |> Map.put(:unit_price, unit_price)
+        |> Map.put(:tax, tax)
         |> Map.put(:line_item_id, li.id)
         |> Map.put(:product_id, v.id)
         |> Map.put(:backordered?, item.delta > 0)

--- a/apps/snitch_core/lib/core/domain/tax.ex
+++ b/apps/snitch_core/lib/core/domain/tax.ex
@@ -1,0 +1,178 @@
+defmodule Snitch.Domain.Tax do
+  @moduledoc """
+  Exposes functions related to Tax Calculation for
+  product and shipping.
+  """
+
+  alias Snitch.Core.Tools.MultiTenancy.Repo
+  alias Snitch.Domain.Calculator.DefaultTaxCalculator, as: TaxCalculator
+  alias Snitch.Data.Schema.{Order, StockLocation, TaxZone, StateZoneMember, CountryZoneMember}
+  alias Snitch.Data.Model.{TaxConfig, Product}
+  import Ecto.Query
+
+  @doc """
+  Returns a map with original price and the tax.
+  ```
+    %{
+      original_price: price,
+      tax: tax_amount
+    }
+  ```
+
+  Calculates tax for a package item or shipping cost associated
+  with a package.
+  """
+
+  @spec calculate(atom, any, Order.t(), StockLocation.t()) :: map
+  def calculate(:package_item, line_item, order, stock_location) do
+    line_item = line_item |> Repo.preload(:product)
+
+    tax_class_id = line_item.product |> Product.get_tax_class_id()
+    tax_config = TaxConfig.get_default()
+    tax_address = get_tax_address(order, stock_location, tax_config)
+    tax_zone = get_tax_zone!(tax_address)
+
+    calculate_item_tax(tax_zone, line_item, tax_config, tax_class_id)
+  end
+
+  def calculate(:shipping, shipping_cost, order, stock_location) do
+    tax_config = TaxConfig.get_default()
+    tax_address = get_tax_address(order, stock_location, tax_config)
+    tax_zone = get_tax_zone!(tax_address)
+
+    calculate_shipping_tax(tax_zone, shipping_cost, tax_config)
+  end
+
+  ################# tax calulation related helpers ##################
+
+  defp calculate_item_tax(tax_zone, line_item, tax_config, tax_class_id) do
+    tax_rates = tax_zone.tax_rates
+
+    amount_with_taxes =
+      Enum.map(tax_rates, fn tax_rate ->
+        tax_by_rate_and_class(tax_rate, tax_class_id, line_item.unit_price, tax_config)
+      end)
+
+    amount_with_tax = List.first(amount_with_taxes)
+
+    total_tax =
+      amount_with_taxes
+      |> Enum.reduce(Money.new!(line_item.unit_price.currency, 0), fn %{tax: tax}, acc ->
+        Money.add!(acc, tax)
+      end)
+      |> Money.mult!(line_item.quantity)
+
+    %{original_amount: amount_with_tax.amount, tax: total_tax}
+  end
+
+  defp calculate_shipping_tax(_tax_zone, shipping_cost, %{shipping_tax_id: nil}) do
+    %{original_amount: shipping_cost, tax: Money.new!(shipping_cost.currency, 0)}
+  end
+
+  defp calculate_shipping_tax(tax_zone, shipping_cost, tax_config) do
+    tax_rates = tax_zone.tax_rates
+
+    amount_with_taxes =
+      Enum.map(tax_rates, fn tax_rate ->
+        tax_by_rate_and_class(tax_rate, tax_config.shipping_tax_id, shipping_cost, tax_config)
+      end)
+
+    total_tax =
+      Enum.reduce(amount_with_taxes, Money.new!(shipping_cost.currency, 0), fn %{tax: tax}, acc ->
+        Money.add!(acc, tax)
+      end)
+
+    amount_with_tax = List.first(amount_with_taxes)
+    %{original_amount: amount_with_tax.amount, tax: total_tax}
+  end
+
+  defp tax_by_rate_and_class(tax_rate, tax_class_id, price, tax_config) do
+    tax_value =
+      Enum.find(tax_rate.tax_rate_class_values, fn value ->
+        value.tax_class.id == tax_class_id
+      end)
+
+    compute_tax(tax_value, price, tax_config)
+  end
+
+  defp compute_tax(nil, price, _tax_config) do
+    %{amount: price, tax: Money.new!(price.currency, 0)}
+  end
+
+  defp compute_tax(tax_value, price, tax_config) do
+    TaxCalculator.compute(tax_value.percent_amount, price, tax_config.included_in_price?)
+  end
+
+  ################### tax zone related helpers ######################
+
+  # Returns tax zone for the supplied state and country id.
+  defp get_tax_zone!(%{state_id: nil, country_id: country_id}) do
+    query =
+      from(tz in TaxZone,
+        join: c_z_member in CountryZoneMember,
+        on: tz.zone_id == c_z_member.zone_id,
+        where: c_z_member.state_id == ^country_id and tz.is_active? == true,
+        select: %TaxZone{id: tz.id, name: tz.name, zone_id: tz.zone_id}
+      )
+
+    tax_zone_query_result(query)
+  end
+
+  defp get_tax_zone!(%{state_id: state_id, country_id: _country_id}) do
+    query =
+      from(tz in TaxZone,
+        join: s_z_member in StateZoneMember,
+        on: tz.zone_id == s_z_member.zone_id,
+        where: s_z_member.state_id == ^state_id,
+        select: %TaxZone{id: tz.id, name: tz.name}
+      )
+
+    tax_zone_query_result(query)
+  end
+
+  defp tax_zone_query_result(query) do
+    [tax_zone] =
+      query
+      |> Repo.all()
+
+    Repo.preload(tax_zone, tax_rates: [tax_rate_class_values: :tax_class])
+  end
+
+  ################ address related helpers #########################
+
+  # Checks for address type set in tax config, and tries to find if, the address
+  # set is present in the order or not. In case, order does not have the address
+  # set, the default address set in tax config is returned.
+  # Returns in the format {state_id: data, country_id: data}, returns
+  # nil for values if respective id's are not set.
+
+  defp get_tax_address(order, stock_location, tax_config) do
+    get_address(tax_config.calculation_address_type, order, stock_location, tax_config)
+  end
+
+  defp get_address(:shipping_address, order, _stock_location, tax_config) do
+    {state_id, country_id} =
+      if order.shipping_address do
+        {order.shipping_address.state_id, order.shipping_address.state_id}
+      else
+        {tax_config.default_state_id, tax_config.default_country_id}
+      end
+
+    %{state_id: state_id, country_id: country_id}
+  end
+
+  defp get_address(:billing_address, order, _stock_location, tax_config) do
+    {state_id, country_id} =
+      if order.billing_address do
+        {order.billing_address.state_id, order.billing_address.state_id}
+      else
+        {tax_config.default_state_id, tax_config.default_country_id}
+      end
+
+    %{state_id: state_id, country_id: country_id}
+  end
+
+  defp get_address(:store_address, _order, stock_location, _tax_config) do
+    %{state_id: stock_location.state_id, country_id: stock_location.country_id}
+  end
+end

--- a/apps/snitch_core/lib/core/domain/tax.ex
+++ b/apps/snitch_core/lib/core/domain/tax.ex
@@ -25,9 +25,9 @@ defmodule Snitch.Domain.Tax do
 
   @spec calculate(atom, any, Order.t(), StockLocation.t()) :: map
   def calculate(:package_item, line_item, order, stock_location) do
-    line_item = line_item |> Repo.preload(:product)
+    line_item = Repo.preload(line_item, :product)
 
-    tax_class_id = line_item.product |> Product.get_tax_class_id()
+    tax_class_id = Product.get_tax_class_id(line_item.product)
     tax_config = TaxConfig.get_default()
     tax_address = get_tax_address(order, stock_location, tax_config)
     tax_zone = get_tax_zone!(tax_address)

--- a/apps/snitch_core/priv/repo/migrations/20190131112645_modify_prod_pack_item_for_tax.exs
+++ b/apps/snitch_core/priv/repo/migrations/20190131112645_modify_prod_pack_item_for_tax.exs
@@ -1,0 +1,13 @@
+defmodule Snitch.Repo.Migrations.ModifyProdPackItemForTax do
+  use Ecto.Migration
+
+  def change do
+    alter table("snitch_products") do
+      add(:tax_class_id, references(:snitch_tax_classes, on_delete: :restrict))
+    end
+
+    alter table("snitch_package_items") do
+      add(:unit_price, String.to_atom("money_with_currency"))
+    end
+  end
+end

--- a/apps/snitch_core/test/data/model/option_type_test.exs
+++ b/apps/snitch_core/test/data/model/option_type_test.exs
@@ -22,13 +22,15 @@ defmodule Snitch.Data.Model.OptionTypeTest do
       |> VTModel.create()
 
     taxon = insert(:taxon)
+    tax_class = insert(:tax_class)
 
     params = %{
       "name" => "ProductXYZ",
       "selling_price" => Money.new("12.99", currency()),
       "max_retail_price" => Money.new("14.99", currency()),
       "taxon_id" => taxon.id,
-      "shipping_category_id" => shipping_category.id
+      "shipping_category_id" => shipping_category.id,
+      "tax_class_id" => tax_class.id
     }
 
     {:ok, product} = ProductModel.create(params)

--- a/apps/snitch_core/test/data/model/package_item_test.exs
+++ b/apps/snitch_core/test/data/model/package_item_test.exs
@@ -102,7 +102,7 @@ defmodule Snitch.Data.Model.PackageItemTest do
 
   describe "get_all/0" do
     test "package_items", context do
-      %{package_item: package_item} = make_package_item(context)
+      %{package_item: _package_item} = make_package_item(context)
       assert PackageItem.get_all() != []
     end
   end

--- a/apps/snitch_core/test/data/model/tax/tax_zone_test.exs
+++ b/apps/snitch_core/test/data/model/tax/tax_zone_test.exs
@@ -4,12 +4,6 @@ defmodule Snitch.Data.Model.TaxZoneTest do
   import Snitch.Factory
   alias Snitch.Data.Model.TaxZone
 
-  @exculsivity %{
-    success: "Tax Zone mutually exclusive of others",
-    failure_state: "Tax Zone with one or more states in zone already present",
-    failure_country: "Tax Zone with one or more countries in zone already present"
-  }
-
   setup :states
   setup :countries
 
@@ -39,7 +33,6 @@ defmodule Snitch.Data.Model.TaxZoneTest do
       zone_1 = insert(:zone, zone_type: "S")
       %{states: states} = context
       setup_state_zone_members(zone_1, states)
-      [state_1, _, _] = states
       insert(:tax_zone, zone: zone_1)
 
       zone_2 = insert(:zone, zone_type: "S")
@@ -51,7 +44,7 @@ defmodule Snitch.Data.Model.TaxZoneTest do
     end
 
     @tag state_count: 3
-    test "fails for missing params", context do
+    test "fails for missing params" do
       params = %{}
       assert {:error, changeset} = TaxZone.create(params)
       assert %{name: ["can't be blank"], zone_id: ["can't be blank"]} == errors_on(changeset)
@@ -82,7 +75,6 @@ defmodule Snitch.Data.Model.TaxZoneTest do
       zone_1 = insert(:zone, zone_type: "C")
       %{countries: countries} = context
       setup_country_zone_members(zone_1, countries)
-      [country_1, _, _] = countries
       insert(:tax_zone, zone: zone_1)
 
       zone_2 = insert(:zone, zone_type: "C")
@@ -145,7 +137,7 @@ defmodule Snitch.Data.Model.TaxZoneTest do
       zone = insert(:zone, zone_type: "C")
       %{countries: countries} = context
       setup_country_zone_members(zone, countries)
-      tax_zone = insert(:tax_zone, zone: zone)
+      insert(:tax_zone, zone: zone)
 
       assert {:error, message} = TaxZone.get(-1)
       assert message == :tax_zone_not_found
@@ -158,7 +150,7 @@ defmodule Snitch.Data.Model.TaxZoneTest do
       zone = insert(:zone, zone_type: "C")
       %{countries: countries} = context
       setup_country_zone_members(zone, countries)
-      tax_zone = insert(:tax_zone, zone: zone)
+      insert(:tax_zone, zone: zone)
 
       assert [_] = TaxZone.get_all()
     end

--- a/apps/snitch_core/test/data/schema/package_item_test.exs
+++ b/apps/snitch_core/test/data/schema/package_item_test.exs
@@ -139,17 +139,17 @@ defmodule Snitch.Data.Schema.PackageItemTest do
     end
   end
 
-  defp product(context) do
+  defp product(_context) do
     product = insert(:product)
     [product: product]
   end
 
-  defp line_item(context) do
+  defp line_item(_context) do
     line_item = insert(:line_item)
     [line_item: line_item]
   end
 
-  defp package(context) do
+  defp package(_context) do
     package = insert(:package)
     [package: package]
   end

--- a/apps/snitch_core/test/data/schema/product_test.exs
+++ b/apps/snitch_core/test/data/schema/product_test.exs
@@ -9,6 +9,7 @@ defmodule Snitch.Data.Schema.ProductTest do
   test "test valid data create_changeset/2" do
     taxon = insert(:taxon)
     shipping_category = insert(:shipping_category)
+    tax_class = insert(:tax_class)
 
     params = %{
       name: "HTC Desire 620",
@@ -16,7 +17,8 @@ defmodule Snitch.Data.Schema.ProductTest do
       selling_price: Money.new("12.99", currency()),
       max_retail_price: Money.new("14.99", currency()),
       taxon_id: taxon.id,
-      shipping_category_id: shipping_category.id
+      shipping_category_id: shipping_category.id,
+      tax_class_id: tax_class.id
     }
 
     changeset = Product.create_changeset(%Product{}, params)

--- a/apps/snitch_core/test/data/schema/tax/tax_config_test.exs
+++ b/apps/snitch_core/test/data/schema/tax/tax_config_test.exs
@@ -19,7 +19,6 @@ defmodule Snitch.Data.Schema.TaxConfigTest do
     end
 
     test "failure for foreign key constraints" do
-      state = insert(:state)
       tax_class = insert(:tax_class)
 
       params = %{

--- a/apps/snitch_core/test/domain/calculator/default_calculator_test.exs
+++ b/apps/snitch_core/test/domain/calculator/default_calculator_test.exs
@@ -2,37 +2,30 @@ defmodule Snitch.Domain.DefaultCalculatorTest do
   use ExUnit.Case, async: true
   use Snitch.DataCase
 
-  alias Snitch.Domain.Calculator.Default, as: DefaultCalculator
-  alias Snitch.Data.Schema.LineItem
+  alias Snitch.Domain.Calculator.DefaultTaxCalculator
 
-  @tax_info %{
-    value: 0.5,
-    included_in_price: false
-  }
-
-  @lineitem %LineItem{
-    order_id: 1,
-    product_id: 1,
-    quantity: 1,
-    unit_price: Money.new("15.00", :USD)
-  }
+  @tax_percent 50
+  @amount Money.new!(:USD, 15)
 
   describe "compute/2" do
     test "tax, isn't included in price" do
-      assert value = %Money{} = DefaultCalculator.compute(@tax_info, @lineitem)
+      assert %{amount: amount, tax: tax} =
+               DefaultTaxCalculator.compute(@tax_percent, @amount, _included = false)
+
       # total price = 15.00
       # tax rate = 0.5
       # tax_value = 15. 00 * 0.5 = 7.50
-      assert Money.equal?(value, Money.new("7.50", :USD))
+      assert Money.equal?(tax, Money.new(:USD, "7.50"))
     end
 
     test "tax, is included in price" do
-      tax_info = %{@tax_info | included_in_price: true}
-      assert value = %Money{} = DefaultCalculator.compute(tax_info, @lineitem)
+      assert %{amount: amount, tax: tax} =
+               DefaultTaxCalculator.compute(@tax_percent, @amount, _included = true)
+
       # total price = 15.00
-      # tax rate = 0.5
+      # tax rate = 50
       # tax_value = 15.00 - ((15.00/1+0.5) = 5.00 = 5.00
-      assert Money.equal?(value, Money.new("5.00", :USD))
+      assert Money.equal?(tax, Money.new("5.00", :USD))
     end
   end
 end

--- a/apps/snitch_core/test/domain/calculator/flat_percent_calculator_test.exs
+++ b/apps/snitch_core/test/domain/calculator/flat_percent_calculator_test.exs
@@ -70,13 +70,12 @@ defmodule Snitch.Domain.Calculator.FlatPercentTest do
         shipping_category: shipping_category
       )
 
-    package_item =
-      insert(:package_item,
-        quantity: quantity,
-        product: product,
-        line_item: line_item,
-        package: package
-      )
+    insert(:package_item,
+      quantity: quantity,
+      product: product,
+      line_item: line_item,
+      package: package
+    )
 
     %{order: order, line_item: line_item}
   end

--- a/apps/snitch_core/test/domain/order/transitions_test.exs
+++ b/apps/snitch_core/test/domain/order/transitions_test.exs
@@ -138,10 +138,7 @@ defmodule Snitch.Domain.Order.TransitionsTest do
     setup :states
 
     setup %{embedded_shipping_methods: methods, states: states} do
-      order = insert(:order, shipping_address: address_manifest(List.first(states)))
-      tax_class_values = %{shipping_tax: %{class: insert(:tax_class), percent: 5}}
-      setup_tax_with_zone_and_rates(tax_class_values, states)
-
+      order = order_with_tax_manifest(states)
       [order: order, packages: [insert(:package, shipping_methods: methods, order: order)]]
     end
 
@@ -174,10 +171,7 @@ defmodule Snitch.Domain.Order.TransitionsTest do
     setup :states
 
     setup %{embedded_shipping_methods: methods, states: states} do
-      order = insert(:order, shipping_address: address_manifest(List.first(states)))
-      tax_class_values = %{shipping_tax: %{class: insert(:tax_class), percent: 5}}
-      setup_tax_with_zone_and_rates(tax_class_values, states)
-
+      order = order_with_tax_manifest(states)
       [order: order, packages: [insert(:package, shipping_methods: methods, order: order)]]
     end
 
@@ -361,6 +355,14 @@ defmodule Snitch.Domain.Order.TransitionsTest do
 
       refute result.valid?
     end
+  end
+
+  defp order_with_tax_manifest(states) do
+    order = insert(:order, shipping_address: address_manifest(List.first(states)))
+    tax_class_values = %{shipping_tax: %{class: insert(:tax_class), percent: 5}}
+    setup_tax_with_zone_and_rates(tax_class_values, states)
+
+    order
   end
 
   defp setup_package_with_shipping(context, quantity, shipping_cost, states) do

--- a/apps/snitch_core/test/domain/order/transitions_test.exs
+++ b/apps/snitch_core/test/domain/order/transitions_test.exs
@@ -132,8 +132,17 @@ defmodule Snitch.Domain.Order.TransitionsTest do
   end
 
   describe "persist_shipment" do
-    setup do
-      [order: insert(:order)]
+    setup :zones
+    setup :shipping_methods
+    setup :embedded_shipping_methods
+    setup :states
+
+    setup %{embedded_shipping_methods: methods, states: states} do
+      order = insert(:order, shipping_address: address_manifest(List.first(states)))
+      tax_class_values = %{shipping_tax: %{class: insert(:tax_class), percent: 5}}
+      setup_tax_with_zone_and_rates(tax_class_values, states)
+
+      [order: order, packages: [insert(:package, shipping_methods: methods, order: order)]]
     end
 
     test "when shipment is empty", %{order: order} do
@@ -146,6 +155,7 @@ defmodule Snitch.Domain.Order.TransitionsTest do
       assert {:ok, []} = result.state.packages
     end
 
+    @tag shipping_method_count: 1, state_count: 3
     test "fails when shipment is erroneous", %{order: order} do
       result =
         order
@@ -161,13 +171,17 @@ defmodule Snitch.Domain.Order.TransitionsTest do
     setup :zones
     setup :shipping_methods
     setup :embedded_shipping_methods
+    setup :states
 
-    setup %{embedded_shipping_methods: methods} do
-      order = insert(:order)
+    setup %{embedded_shipping_methods: methods, states: states} do
+      order = insert(:order, shipping_address: address_manifest(List.first(states)))
+      tax_class_values = %{shipping_tax: %{class: insert(:tax_class), percent: 5}}
+      setup_tax_with_zone_and_rates(tax_class_values, states)
+
       [order: order, packages: [insert(:package, shipping_methods: methods, order: order)]]
     end
 
-    @tag shipping_method_count: 1
+    @tag shipping_method_count: 1, state_count: 3
     test "with packages", %{order: order, packages: [package], shipping_methods: [sm]} do
       preference = [
         %{package_id: package.id, shipping_method_id: sm.id}
@@ -183,16 +197,17 @@ defmodule Snitch.Domain.Order.TransitionsTest do
       assert {:ok, %{packages: _}} = Repo.transaction(result.multi)
     end
 
-    @tag shipping_method_count: 1
-    test "check order total after tranisition",
+    @tag shipping_method_count: 1, state_count: 3
+    test "check order total after transition",
          %{
-           shipping_methods: [sm]
+           shipping_methods: [sm],
+           states: states
          } = context do
       set_cost = 20
       quantity = 3
 
       %{order: order, package: package, shipping_rule: shipping_rule} =
-        setup_package_with_shipping(context, quantity, set_cost)
+        setup_package_with_shipping(context, quantity, set_cost, states)
 
       preference = [
         %{package_id: package.id, shipping_method_id: sm.id}
@@ -213,7 +228,11 @@ defmodule Snitch.Domain.Order.TransitionsTest do
       line_item_total = OrderDomain.line_item_total(order)
       [package] = order.packages
 
-      final_order_total = line_item_total |> Money.add!(package.cost) |> Money.round()
+      final_order_total =
+        line_item_total
+        |> Money.add!(package.cost)
+        |> Money.add!(package.shipping_tax)
+        |> Money.round()
 
       assert result.valid?
 
@@ -328,13 +347,12 @@ defmodule Snitch.Domain.Order.TransitionsTest do
           origin: stock_item.stock_location
         )
 
-      package_item =
-        insert(:package_item,
-          quantity: 7,
-          product: product,
-          line_item: line_item,
-          package: package
-        )
+      insert(:package_item,
+        quantity: 7,
+        product: product,
+        line_item: line_item,
+        package: package
+      )
 
       result =
         order
@@ -345,7 +363,7 @@ defmodule Snitch.Domain.Order.TransitionsTest do
     end
   end
 
-  defp setup_package_with_shipping(context, quantity, shipping_cost) do
+  defp setup_package_with_shipping(context, quantity, shipping_cost, states) do
     %{embedded_shipping_methods: embedded_shipping_methods} = context
 
     # setup stock for product
@@ -370,7 +388,10 @@ defmodule Snitch.Domain.Order.TransitionsTest do
 
     # make order and it's packages
     product = stock_item.product
-    order = insert(:order, state: :address)
+
+    order =
+      insert(:order, state: :address, shipping_address: address_manifest(List.first(states)))
+
     line_item = insert(:line_item, order: order, product: product, quantity: quantity)
 
     package =
@@ -391,5 +412,19 @@ defmodule Snitch.Domain.Order.TransitionsTest do
       )
 
     %{order: order, package: package, shipping_rule: shipping_rule}
+  end
+
+  defp address_manifest(state) do
+    %{
+      first_name: "someone",
+      last_name: "enoemos",
+      address_line_1: "BR Ambedkar Chowk",
+      address_line_2: "street",
+      zip_code: "11111",
+      city: "Rajendra Nagar",
+      phone: "1234567890",
+      country_id: state.country_id,
+      state_id: state.id
+    }
   end
 end

--- a/apps/snitch_core/test/domain/package_test.exs
+++ b/apps/snitch_core/test/domain/package_test.exs
@@ -8,37 +8,56 @@ defmodule Snitch.Domain.PackageTest do
   alias Snitch.Domain.Package
   alias Snitch.Data.Model.GeneralConfiguration, as: GCModel
 
+  setup :states
+
   describe "set_shipping_method/2" do
     setup :zones
     setup :shipping_methods
     setup :embedded_shipping_methods
 
-    setup %{embedded_shipping_methods: methods} do
-      [package: insert(:package, shipping_methods: methods)]
+    setup %{embedded_shipping_methods: methods, states: states} do
+      order = insert(:order, shipping_address: address_manifest(List.first(states)))
+      tax_class_values = %{shipping_tax: %{class: insert(:tax_class), percent: 5}}
+      setup_tax_with_zone_and_rates(tax_class_values, states)
+      package = insert(:package, shipping_methods: methods)
+
+      [package: package, order: order]
     end
 
     setup :verify_on_exit!
 
-    @tag shipping_method_count: 1
-    test "with valid shipping method", %{package: package, shipping_methods: [sm]} do
-      assert {:ok, package} = Package.set_shipping_method(package, sm.id)
+    @tag state_count: 3, shipping_method_count: 1
+    test "with valid shipping method", context do
+      %{package: package, shipping_methods: [sm], order: order} = context
+      assert {:ok, package} = Package.set_shipping_method(package, sm.id, order)
       assert package.shipping_method_id
       assert package.cost
       assert package.shipping_tax
     end
 
     @tag shipping_method_count: 1
-    test "with invalid shipping method", %{package: package, shipping_methods: [sm]} do
-      assert {:error, cs} = Package.set_shipping_method(package, -1)
+    test "with invalid shipping method", context do
+      %{package: package, shipping_methods: [sm], order: order} = context
+
+      assert {:error, cs} = Package.set_shipping_method(package, -1, order)
       assert %{shipping_method_id: ["can't be blank"]} == errors_on(cs)
 
-      assert {:error, cs} = Package.set_shipping_method(package, sm.id + 1)
+      assert {:error, cs} = Package.set_shipping_method(package, sm.id + 1, order)
       assert %{shipping_method_id: ["can't be blank"]} == errors_on(cs)
     end
   end
 
-  test "shipping_tax/1" do
-    currency = GCModel.fetch_currency()
-    assert Package.shipping_tax(nil) == Money.zero(currency)
+  defp address_manifest(state) do
+    %{
+      first_name: "someone",
+      last_name: "enoemos",
+      address_line_1: "BR Ambedkar Chowk",
+      address_line_2: "street",
+      zip_code: "11111",
+      city: "Rajendra Nagar",
+      phone: "1234567890",
+      country_id: state.country_id,
+      state_id: state.id
+    }
   end
 end

--- a/apps/snitch_core/test/domain/tax_test.exs
+++ b/apps/snitch_core/test/domain/tax_test.exs
@@ -1,0 +1,171 @@
+defmodule Snitch.Domain.TaxTest do
+  @moduledoc false
+
+  use ExUnit.Case
+  use Snitch.DataCase
+  import Snitch.Factory
+  alias Snitch.Domain.Tax
+
+  setup :countries
+  setup :states
+
+  describe "caluclate/4 for package item" do
+    setup do
+      stock_item = insert(:stock_item, count_on_hand: 5)
+      product = stock_item.product
+      [tax_class: product.tax_class, product: product, stock_item: stock_item]
+    end
+
+    @tag state_count: 3
+    test "tax address is shipping and, order has it set, tax included", context do
+      zone = insert(:zone, zone_type: "S")
+      %{tax_class: tax_class, product: product, states: states, stock_item: stock_item} = context
+      [state_1, state_2, _] = states
+      setup_state_zone_members(zone, states)
+      shipping_address = address_manifest(:shipping, state_1)
+
+      order_params = %{
+        product: product,
+        shipping_address: shipping_address,
+        billing_address: nil,
+        quantity_li: 2
+      }
+
+      %{order: order, line_item: line_item} = order_manifest(order_params)
+
+      tax_params = %{zone: zone, address: :shipping_address, included: true, state: state_2}
+      %{tax_zone: tax_zone} = tax_manifest(tax_params)
+      tax_rate_params = %{tax_zone: tax_zone, value_manifest: [%{class: tax_class, percent: 5}]}
+      tax_rate_manifest(tax_rate_params)
+
+      assert %{original_amount: tax_less_amount, tax: tax} =
+               Tax.calculate(:package_item, line_item, order, stock_item.stock_location)
+
+      %{amount: calculated_amount, tax: tax_value} =
+        included_tax_calculation(line_item.unit_price, 5, line_item.quantity)
+
+      assert calculated_amount == tax_less_amount
+      assert tax == tax_value
+    end
+
+    @tag state_count: 3
+    test "tax address is shipping and, order has it set, tax excluded", context do
+      zone = insert(:zone, zone_type: "S")
+      %{tax_class: tax_class, product: product, states: states, stock_item: stock_item} = context
+      [state_1, state_2, _] = states
+      setup_state_zone_members(zone, states)
+      shipping_address = address_manifest(:shipping, state_1)
+
+      order_params = %{
+        product: product,
+        shipping_address: shipping_address,
+        billing_address: nil,
+        quantity_li: 2
+      }
+
+      %{order: order, line_item: line_item} = order_manifest(order_params)
+
+      tax_params = %{zone: zone, address: :shipping_address, included: false, state: state_2}
+      %{tax_zone: tax_zone} = tax_manifest(tax_params)
+      tax_rate_params = %{tax_zone: tax_zone, value_manifest: [%{class: tax_class, percent: 5}]}
+      tax_rate_manifest(tax_rate_params)
+
+      assert %{original_amount: tax_less_amount, tax: tax} =
+               Tax.calculate(:package_item, line_item, order, stock_item.stock_location)
+
+      %{amount: calculated_amount, tax: tax_value} =
+        excluded_tax_calculation(line_item.unit_price, 5, line_item.quantity)
+
+      assert calculated_amount == tax_less_amount
+      assert tax == tax_value
+    end
+  end
+
+  defp order_manifest(params) do
+    order =
+      insert(:order,
+        shipping_address: params.shipping_address,
+        billing_address: params.billing_address
+      )
+
+    line_item =
+      insert(:line_item, order: order, product: params.product, quantity: params.quantity_li)
+
+    %{order: order, line_item: line_item}
+  end
+
+  defp tax_manifest(params) do
+    insert(:tax_config,
+      default_state: params.state,
+      default_country: params.state.country,
+      calculation_address_type: params.address,
+      included_in_price?: params.included
+    )
+
+    tax_zone = insert(:tax_zone, zone: params.zone)
+
+    %{tax_zone: tax_zone}
+  end
+
+  defp tax_rate_manifest(params) do
+    tax_rate = insert(:tax_rate, tax_zone: params.tax_zone)
+
+    values = params.value_manifest
+
+    Enum.map(values, fn %{class: class, percent: percent} ->
+      insert(:tax_rate_class_value, tax_rate: tax_rate, tax_class: class, percent_amount: percent)
+    end)
+  end
+
+  defp setup_state_zone_members(zone, states) do
+    Enum.each(states, fn state ->
+      insert(:state_zone_member, zone: zone, state: state)
+    end)
+  end
+
+  defp setup_country_zone_members(zone, countries) do
+    Enum.each(countries, fn country ->
+      insert(:country_zone_member, zone: zone, country: country)
+    end)
+  end
+
+  defp address_manifest(:shipping, state) do
+    %{
+      first_name: "someone",
+      last_name: "enoemos",
+      address_line_1: "BR Ambedkar Chowk",
+      address_line_2: "street",
+      zip_code: "11111",
+      city: "Rajendra Nagar",
+      phone: "1234567890",
+      country_id: state.country_id,
+      state_id: state.id
+    }
+  end
+
+  defp address_manifest(:billing, state) do
+    address_manifest(:shipping, state)
+  end
+
+  defp included_tax_calculation(amount, tax_percent, quantity) do
+    offset =
+      amount
+      |> Money.mult!(100)
+      |> Money.div!(100 + tax_percent)
+      |> Money.round(currency_digits: :cash)
+
+    tax_value = amount |> Money.sub!(offset) |> Money.mult!(quantity)
+    %{amount: offset, tax: tax_value}
+  end
+
+  defp excluded_tax_calculation(amount, tax_percent, quantity) do
+    tax_value =
+      amount
+      |> Money.mult!(tax_percent)
+      |> Money.div!(100)
+      |> Money.round(currency_digits: :cash)
+      |> Money.mult!(quantity)
+
+    %{amount: amount, tax: tax_value}
+  end
+end

--- a/apps/snitch_core/test/support/factory/factory.ex
+++ b/apps/snitch_core/test/support/factory/factory.ex
@@ -32,7 +32,6 @@ defmodule Snitch.Factory do
     Permission,
     Role,
     User,
-    Variant,
     Variation,
     Product,
     ProductBrand,
@@ -105,13 +104,9 @@ defmodule Snitch.Factory do
   def order_factory do
     %Order{
       number: sequence("order"),
-      state: :cart
-    }
-  end
-
-  def taxon_factory do
-    %Taxon{
-      name: sequence("taxon")
+      state: :cart,
+      shipping_address: nil,
+      billing_address: nil
     }
   end
 
@@ -221,14 +216,6 @@ defmodule Snitch.Factory do
     %Permission{
       code: sequence(:code, ["manage_products", "manage_orders", "manage_all"]),
       description: "can manage respective"
-    }
-  end
-
-  def product_factory do
-    %Product{
-      name: sequence(:product, &"shoes-nike-#{&1}"),
-      description: "awesome products",
-      slug: sequence(:slug, &"nike-#{&1}")
     }
   end
 

--- a/apps/snitch_core/test/support/factory/product.ex
+++ b/apps/snitch_core/test/support/factory/product.ex
@@ -11,7 +11,8 @@ defmodule Snitch.Factory.Product do
           selling_price: Money.new("12.99", currency()),
           max_retail_price: Money.new("14.99", currency()),
           shipping_category: build(:shipping_category),
-          state: :active
+          state: :active,
+          tax_class: build(:tax_class)
         }
       end
     end

--- a/apps/snitch_core/test/support/factory/shipping.ex
+++ b/apps/snitch_core/test/support/factory/shipping.ex
@@ -59,7 +59,7 @@ defmodule Snitch.Factory.Shipping do
         %{
           items: [
             %{
-              line_item: build(:line_item),
+              line_item: insert(:line_item),
               variant: build(:variant),
               delta: 0,
               quantity: 4,
@@ -84,7 +84,7 @@ defmodule Snitch.Factory.Shipping do
                 line_item: line_item,
                 variant: v,
                 delta: 0,
-                quantity: 4,
+                quantity: line_item.quantity,
                 state: :fulfilled,
                 tax: Money.zero(:USD)
               }


### PR DESCRIPTION
## Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->
At present tax needs to be handled for product and shipping. The PR adds tax domain module which handles all the business logic and edge cases related to tax and is used in respective domain modules for package item and package to set taxes for product and shipping. 

## This change addresses the need by:
<!--- List and detail all changes made in this PR. -->
- Adds tax_class field to products so now all the products have a belongs to relationship with tax_class.
```
product bleongs_to tax_class
```
This relationship allows tax calculation for a product by findind respective values in a tax rate for that particular tax_class.
- Unit price field has been added to `package_item` this was done so as to keep the actual price after tax calculation which is exclusive of the tax.
- Adds tax domain to handle all the business logic. At present tax domain handles tax calculation for 
product and shipping.

[delivers #163283496]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read [CONTRIBUTING.md][contributing].
- [x] My code follows the [style guidelines][contributing] of this project.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [x] I have updated the documentation wherever necessary.
- [x] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

