### PR TITLE
Add default zone and tax zone

### DIFF
--- a/apps/admin_app/lib/admin_app_web/templates/tax/tax_zone/index.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/tax/tax_zone/index.html.eex
@@ -21,6 +21,11 @@
                      <div class="row">
                         <div class="col"> <%= tax_zone.name %> </div>
                         <div class="col"><%= zone_type(tax_zone) %></div>
+                        <%= if tax_zone.is_default do %>
+                           <div class="col-3"><kbd>Default</kbd></div>
+                        <% else %>
+                           <div class="col-3"></div>
+                        <% end %>
                         <%= if tax_zone.is_active? do %>
                           <div class="col"><kbd>Active</kbd></div>
                         <% else %>
@@ -37,8 +42,10 @@
                   </a>
                   <div class="dropdown-menu dropdown-menu-right" >
                      <%= link("Edit", to: tax_zone_path(@conn, :edit, tax_zone.id), class: "dropdown-item") %>
-                     <%= link("Delete", to: tax_zone_path(@conn, :delete, tax_zone.id),
-                        method: :delete, data: [confirm: "Are you sure to delete"], class: "dropdown-item") %>
+                     <%= unless tax_zone.is_default do %>
+                        <%= link("Delete", to: tax_zone_path(@conn, :delete, tax_zone.id),
+                        method: :delete, data: [confirm: "Are you sure to delete"], class: "dropdown-item") %>  
+                     <% end %>
                   </div>
                </div>
             </div>

--- a/apps/admin_app/lib/admin_app_web/templates/zone/index.html.eex
+++ b/apps/admin_app/lib/admin_app_web/templates/zone/index.html.eex
@@ -21,28 +21,34 @@
                   </div>
                   <div class="media-body">
                      <div class="row">
-                        <div class="col-5">   <%= zone.name %>    </div>
-                        <div class="col-4">   <%= zone.description %>    </div>
+                        <div class="col-3">   <%= zone.name %>    </div>
+                        <%= if zone.is_default do %>
+                           <div class="col-3"><kbd>Default</kbd></div>
+                        <% else %>
+                           <div class="col-3"></div>
+                        <% end %>
                         <div class="col-3">  <%= get_zone_by_type(zone) %></div>
                      </div>
                   </div>
                </div>
             </div>
-            <div class="col-1 float-right">
-               <div class="dropdown col-12 p-0 float-right options-container">
-                  <a class="p-2 dropdown-toggle options" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  <i class="fa fa-cog"></i>
-                  </a>
-                  <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
-                     <%= link("Edit", to: zone_path(@conn, :edit, zone.id), class: "dropdown-item")%>
-                     <%= if check_min_zones() do %>
-                      <%= link("Delete", to: zone_path(@conn, :delete, zone.id), method: :delete,
-                        data: [confirm: "Are you sure?"], class: "dropdown-item")%>
-                     <% end %>
-                     
+            <%= unless zone.is_default do %>
+               <div class="col-1 float-right">
+                  <div class="dropdown col-12 p-0 float-right options-container">
+                     <a class="p-2 dropdown-toggle options" href="#" role="button" id="dropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                     <i class="fa fa-cog"></i>
+                     </a>
+                     <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuLink">
+                        <%= link("Edit", to: zone_path(@conn, :edit, zone.id), class: "dropdown-item")%>
+                        <%= if check_min_zones() do %>
+                        <%= link("Delete", to: zone_path(@conn, :delete, zone.id), method: :delete,
+                           data: [confirm: "Are you sure?"], class: "dropdown-item")%>
+                        <% end %>
+                        
+                     </div>
                   </div>
                </div>
-            </div>
+            <% end %> 
          </div>
       </div>
       <% end %>

--- a/apps/snitch_core/lib/core/data/model/tax/tax_zone.ex
+++ b/apps/snitch_core/lib/core/data/model/tax/tax_zone.ex
@@ -41,9 +41,18 @@ defmodule Snitch.Data.Model.TaxZone do
     QH.get(TaxZone, id, Repo)
   end
 
+  @doc """
+  Returns the default tax zone with it's rates.
+  """
+  def get_default() do
+    TaxZone
+    |> Repo.get_by(is_default: true)
+    |> Repo.preload(tax_rates: [tax_rate_class_values: :tax_class])
+  end
+
   @spec get_all() :: [TaxZone.t()]
   def get_all() do
-    Repo.all(TaxZone)
+    TaxZone |> Repo.all() |> Repo.preload(:zone)
   end
 
   @doc """

--- a/apps/snitch_core/lib/core/data/model/zone/zone.ex
+++ b/apps/snitch_core/lib/core/data/model/zone/zone.ex
@@ -157,9 +157,13 @@ defmodule Snitch.Data.Model.Zone do
     get(id)
   end
 
+  @doc """
+  Returns a list of zones with the default zone as the first element
+  of the list.
+  """
   def get_all() do
     Zone
-    |> order_by([z], asc: z.name)
+    |> order_by([z], desc: z.is_default)
     |> Repo.all()
   end
 

--- a/apps/snitch_core/lib/core/data/schema/tax/tax_zone.ex
+++ b/apps/snitch_core/lib/core/data/schema/tax/tax_zone.ex
@@ -44,6 +44,7 @@ defmodule Snitch.Data.Schema.TaxZone do
   schema "snitch_tax_zones" do
     field(:name, :string)
     field(:is_active?, :boolean, default: true)
+    field(:is_default, :boolean, default: false)
 
     belongs_to(:zone, Zone, on_replace: :raise)
     has_many(:tax_rates, TaxRate)
@@ -52,7 +53,7 @@ defmodule Snitch.Data.Schema.TaxZone do
   end
 
   @required ~w(name zone_id)a
-  @optional ~w(is_active?)a
+  @optional ~w(is_active? is_default)a
   @permitted @required ++ @optional
 
   def create_changeset(%__MODULE__{} = tax_zone, params) do
@@ -67,7 +68,7 @@ defmodule Snitch.Data.Schema.TaxZone do
     |> common_changeset()
   end
 
-  def common_changeset(changeset) do
+  defp common_changeset(changeset) do
     changeset
     |> validate_required(@required)
     |> unique_constraint(:name)
@@ -77,6 +78,10 @@ defmodule Snitch.Data.Schema.TaxZone do
       message: "tax zone exists with supplied zone"
     )
     |> tax_zone_exclusivity()
+    |> unique_constraint(:is_default,
+      name: :unique_default_tax_zone,
+      message: "unique default tax zone"
+    )
   end
 
   # Runs a check for mutual exclusivity with other tax zones so that, no two

--- a/apps/snitch_core/lib/core/data/schema/zone/zone.ex
+++ b/apps/snitch_core/lib/core/data/schema/zone/zone.ex
@@ -29,11 +29,13 @@ defmodule Snitch.Data.Schema.Zone do
     field(:description, :string)
     field(:zone_type, :string)
     field(:members, :any, virtual: true)
+    field(:is_default, :boolean, default: false)
+
     timestamps()
   end
 
   @required_fields ~w(name zone_type)a
-  @optional_fields ~w(description)a
+  @optional_fields ~w(description is_default)a
   @create_fields @required_fields ++ @optional_fields
   @doc """
   Returns a `Zone` changeset to create a new `zone`.

--- a/apps/snitch_core/priv/repo/migrations/20190206050019_add_default_field_zone.exs
+++ b/apps/snitch_core/priv/repo/migrations/20190206050019_add_default_field_zone.exs
@@ -1,0 +1,19 @@
+defmodule Snitch.Repo.Migrations.AddDefaultToTaxZone do
+  use Ecto.Migration
+
+  def change do
+    alter table("snitch_zones") do
+      add(:is_default, :boolean, default: false)
+    end
+
+    create unique_index("snitch_zones", [:is_default], where: "is_default=true",
+      name: :unique_default_zone)
+
+    alter table("snitch_tax_zones") do
+      add(:is_default, :boolean, default: false)
+    end
+
+    create unique_index("snitch_tax_zones", [:is_default], where: "is_default=true",
+      name: :unique_default_tax_zone)
+  end
+end

--- a/apps/snitch_core/priv/repo/seed/shipping.ex
+++ b/apps/snitch_core/priv/repo/seed/shipping.ex
@@ -14,7 +14,7 @@ defmodule Snitch.Seed.Shipping do
 
   @zone_manifest %{
     "apac" => %{zone_type: "C"},
-    "india" => %{zone_type: "S"},
+    "india" => %{zone_type: "S", is_default: true},
     "north-india" => %{zone_type: "S"}
   }
 

--- a/apps/snitch_core/priv/repo/seed/tax.ex
+++ b/apps/snitch_core/priv/repo/seed/tax.ex
@@ -6,7 +6,7 @@ defmodule Snitch.Seed.Tax do
   Country and states to be seeded first.
   """
   alias Snitch.Core.Tools.MultiTenancy.Repo
-  alias Snitch.Data.Schema.{TaxClass, TaxConfig}
+  alias Snitch.Data.Schema.{TaxClass, TaxConfig, Zone, TaxZone}
   alias Snitch.Data.Model.TaxClass, as: TaxClassModel
   alias Snitch.Data.Model.Country
 
@@ -24,9 +24,17 @@ defmodule Snitch.Seed.Tax do
     updated_at: DateTime.utc_now()
   }
 
+  @default_tax_zone_params %{
+    name: "Default Tax Zone",
+    is_active?: true,
+    zone_id: nil,
+    is_default: true
+  }
+
   def seed() do
     seed_tax_classes()
     seed_tax_config()
+    seed_default_tax_zone!()
   end
 
   def seed_tax_classes() do
@@ -56,5 +64,13 @@ defmodule Snitch.Seed.Tax do
 
     Repo.delete_all(TaxConfig)
     Repo.insert(changeset, returning: false)
+  end
+
+  def seed_default_tax_zone!() do
+    default_zone = Repo.get_by!(Zone, is_default: true)
+    params = %{@default_tax_zone_params | zone_id: default_zone.id}
+    changeset = TaxZone.create_changeset(%TaxZone{}, params)
+
+    Repo.insert(changeset, on_conflict: :nothing)
   end
 end

--- a/apps/snitch_core/test/data/model/tax/tax_zone_test.exs
+++ b/apps/snitch_core/test/data/model/tax/tax_zone_test.exs
@@ -168,6 +168,14 @@ defmodule Snitch.Data.Model.TaxZoneTest do
     assert message == :tax_zone_not_found
   end
 
+  test "get_default tax zone" do
+    zone = insert(:zone, zone_type: "C")
+    tax_zone = insert(:tax_zone, zone: zone, is_default: true)
+
+    returned_tax_zone = TaxZone.get_default()
+    assert returned_tax_zone.id == tax_zone.id
+  end
+
   defp setup_state_zone_members(zone, states) do
     Enum.each(states, fn state ->
       insert(:state_zone_member, zone: zone, state: state)

--- a/apps/snitch_core/test/data/schema/tax/tax_zone_test.exs
+++ b/apps/snitch_core/test/data/schema/tax/tax_zone_test.exs
@@ -22,7 +22,7 @@ defmodule Snitch.Data.Schema.TaxZoneTest do
 
     test "fails for unique constraitnts" do
       zone = insert(:zone, zone_type: "S")
-      tax_zone = insert(:tax_zone, zone: zone)
+      tax_zone = insert(:tax_zone, zone: zone, is_default: true)
 
       params = %{name: "AAPCTax", zone_id: zone.id}
       changeset = TaxZone.create_changeset(%TaxZone{}, params)
@@ -37,6 +37,12 @@ defmodule Snitch.Data.Schema.TaxZoneTest do
       {:error, changeset} = Repo.insert(changeset)
 
       assert %{name: ["has already been taken"]} == errors_on(changeset)
+
+      params = %{name: "EUVAT", is_default: true, zone_id: zone_new.id}
+      changeset = TaxZone.create_changeset(%TaxZone{}, params)
+
+      {:error, changeset} = Repo.insert(changeset)
+      assert %{is_default: ["unique default tax zone"]} == errors_on(changeset)
     end
   end
 end

--- a/apps/snitch_core/test/support/factory/tax.ex
+++ b/apps/snitch_core/test/support/factory/tax.ex
@@ -35,6 +35,7 @@ defmodule Snitch.Factory.Tax do
         %TaxZone{
           name: sequence(:tax_zone_name, fn id -> "taxzone_#{id}" end),
           is_active?: false,
+          is_default: false,
           zone: build(:zone)
         }
       end
@@ -58,6 +59,7 @@ defmodule Snitch.Factory.Tax do
 
       def setup_tax_with_zone_and_rates(tax_rate_values, states) do
         zone = insert(:zone, zone_type: "S")
+        zone_c = insert(:zone, zone_type: "C")
 
         Enum.each(states, fn state ->
           insert(:state_zone_member, zone: zone, state: state)
@@ -74,6 +76,7 @@ defmodule Snitch.Factory.Tax do
         )
 
         tax_zone = insert(:tax_zone, zone: zone)
+        _default_tax_zone = insert(:tax_zone, zone: zone_c, is_default: true)
 
         tax_rate = insert(:tax_rate, tax_zone: tax_zone)
 


### PR DESCRIPTION
## Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->
Needed to set the default tax zone along with the default zone.  The default `tax zone` acts as a fall back tax zone in case no `tax_zones` are found for order address.

__Comment__
In seeds, a change has been made to set a default zone with all the states of India.
## This change addresses the need by:
<!--- List and detail all changes made in this PR. -->
- Adds is_default to zone schema and migration.
- Modified seeds to set default zone and tax zone.
- Made changes in UI to show tax zone and zone.

[delivers #163722418]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

