### PR TITLE
Add to cart fix

### DIFF
--- a/apps/snitch_core/lib/core/domain/stock/quantifier.ex
+++ b/apps/snitch_core/lib/core/domain/stock/quantifier.ex
@@ -29,11 +29,11 @@ defmodule Snitch.Domain.Stock.Quantifier do
   def validate_in_stock(%Ecto.Changeset{valid?: true} = changeset) do
     with {_, product_id} <- fetch_field(changeset, :product_id),
          {_, quantity} <- fetch_field(changeset, :quantity),
-         true <- is_inventory_tracking_enabled(product_id),
+         {:track_inventory, true} <- {:track_inventory, is_inventory_tracking_enabled(product_id)},
          total when quantity <= total and not is_nil(total) <- total_on_hand(product_id) do
       changeset
     else
-      false ->
+      {:track_inventory, false} ->
         changeset
 
       _ ->

--- a/apps/snitch_core/lib/core/domain/stock/quantifier.ex
+++ b/apps/snitch_core/lib/core/domain/stock/quantifier.ex
@@ -6,6 +6,7 @@ defmodule Snitch.Domain.Stock.Quantifier do
   use Snitch.Domain
   import Ecto.Changeset
   alias Model.StockItem, as: StockItemModel
+  alias Model.Product, as: ProductModel
 
   @doc """
   Returns a `total available inventory count` for stock items
@@ -28,11 +29,27 @@ defmodule Snitch.Domain.Stock.Quantifier do
   def validate_in_stock(%Ecto.Changeset{valid?: true} = changeset) do
     with {_, product_id} <- fetch_field(changeset, :product_id),
          {_, quantity} <- fetch_field(changeset, :quantity),
+         true <- is_inventory_tracking_enabled(product_id),
          total when quantity <= total and not is_nil(total) <- total_on_hand(product_id) do
       changeset
     else
+      false ->
+        changeset
+
       _ ->
         add_error(changeset, :stock, "Stock Insufficient")
+    end
+  end
+
+  defp is_inventory_tracking_enabled(product_id) do
+    {:ok, product} = ProductModel.get(product_id)
+
+    case product.inventory_tracking do
+      :none ->
+        false
+
+      _ ->
+        true
     end
   end
 end

--- a/apps/snitch_core/test/data/model/general_configuration_test.exs
+++ b/apps/snitch_core/test/data/model/general_configuration_test.exs
@@ -82,4 +82,16 @@ defmodule Snitch.Data.Model.GeneralConfigurationTest do
       assert {:error, _} = GCModel.update(gc, params)
     end
   end
+
+  describe "fetch currency" do
+
+    test "if general currency not set", %{general_config: gc} do
+      GCModel.delete_general_configuration(gc.id) 
+      assert "USD" == GCModel.fetch_currency()
+    end
+
+    test "if general currency is set", %{general_config: gc} do
+      assert gc.currency == GCModel.fetch_currency()
+    end
+  end
 end

--- a/apps/snitch_core/test/data/model/line_item_test.exs
+++ b/apps/snitch_core/test/data/model/line_item_test.exs
@@ -5,7 +5,7 @@ defmodule Snitch.Data.Model.LineItemTest do
   import Mox, only: [expect: 3, verify_on_exit!: 1]
   import Snitch.Factory
 
-  alias Snitch.Data.Model.{LineItem, Order}
+  alias Snitch.Data.Model.{LineItem, Order, Product}
   alias Snitch.Data.Model.GeneralConfiguration, as: GCModel
 
   describe "with valid params" do
@@ -93,6 +93,16 @@ defmodule Snitch.Data.Model.LineItemTest do
                LineItem.create(%{line_item_params(variant) | order_id: order.id})
 
       assert %{stock: ["Stock Insufficient"]} = errors_on(changeset)
+    end
+
+    @tag variant_count: 1
+    test "successfully if stock insufficient and inventory tracking disabled", %{
+      variants: [variant]
+    } do
+      order = insert(:order, line_items: [])
+      taxon = insert(:taxon)
+      {:ok, variant} = Product.update(variant, %{inventory_tracking: :none, taxon_id: taxon.id})
+      assert {:ok, line_item} = LineItem.create(%{line_item_params(variant) | order_id: order.id})
     end
   end
 

--- a/apps/snitch_core/test/data/model/line_item_test.exs
+++ b/apps/snitch_core/test/data/model/line_item_test.exs
@@ -8,85 +8,85 @@ defmodule Snitch.Data.Model.LineItemTest do
   alias Snitch.Data.Model.{LineItem, Order}
   alias Snitch.Data.Model.GeneralConfiguration, as: GCModel
 
-  describe "with valid params" do
-    setup :variants
-    setup :good_line_items
+  # describe "with valid params" do
+  #   setup :variants
+  #   setup :good_line_items
 
-    test "update_unit_price/1", context do
-      %{line_items: line_items} = context
-      priced_items = LineItem.update_unit_price(line_items)
-      assert Enum.all?(priced_items, fn %{unit_price: price} -> not is_nil(price) end)
-    end
+  #   test "update_unit_price/1", context do
+  #     %{line_items: line_items} = context
+  #     priced_items = LineItem.update_unit_price(line_items)
+  #     assert Enum.all?(priced_items, fn %{unit_price: price} -> not is_nil(price) end)
+  #   end
 
-    test "compute_total/1", context do
-      %{line_items: line_items} = context
-      priced_items = LineItem.update_unit_price(line_items)
-      assert %Money{} = LineItem.compute_total(priced_items)
-    end
-  end
+  #   test "compute_total/1", context do
+  #     %{line_items: line_items} = context
+  #     priced_items = LineItem.update_unit_price(line_items)
+  #     assert %Money{} = LineItem.compute_total(priced_items)
+  #   end
+  # end
 
-  describe "with invalid params" do
-    setup :variants
-    setup :bad_line_items
+  # describe "with invalid params" do
+  #   setup :variants
+  #   setup :bad_line_items
 
-    test "update_unit_price/1", %{line_items: line_items} do
-      priced_items = LineItem.update_unit_price(line_items)
+  #   test "update_unit_price/1", %{line_items: line_items} do
+  #     priced_items = LineItem.update_unit_price(line_items)
 
-      assert [
-               %{quantity: 2, product_id: -1},
-               %{quantity: nil, unit_price: %Money{}, product_id: _},
-               %{quantity: 2, product_id: nil}
-             ] = priced_items
-    end
-  end
+  #     assert [
+  #              %{quantity: 2, product_id: -1},
+  #              %{quantity: nil, unit_price: %Money{}, product_id: _},
+  #              %{quantity: 2, product_id: nil}
+  #            ] = priced_items
+  #   end
+  # end
 
-  describe "compute_total/1 with empty list" do
-    setup :verify_on_exit!
+  # describe "compute_total/1 with empty list" do
+  #   setup :verify_on_exit!
 
-    test "when default currency is set in the store" do
-      config = insert(:general_config)
-      assert GCModel.fetch_currency() == config.currency
-      assert Money.zero(config.currency) == LineItem.compute_total([])
-    end
+  #   test "when default currency is set in the store" do
+  #     config = insert(:general_config)
+  #     assert GCModel.fetch_currency() == config.currency
+  #     assert Money.zero(config.currency) == LineItem.compute_total([])
+  #   end
 
-    test "when default currency is not set" do
-      assert GCModel.fetch_currency() == "USD"
-      assert Money.zero("USD") == LineItem.compute_total([])
-    end
-  end
+  #   test "when default currency is not set" do
+  #     assert GCModel.fetch_currency() == "USD"
+  #     assert Money.zero("USD") == LineItem.compute_total([])
+  #   end
+  # end
 
   describe "create/1" do
     setup :variants
     setup :stock_items_setup
 
-    @tag stock_item_count: 1
-    test "fails without an existing order or variant", %{stock_items: [si]} do
-      product = si.product
-      assert {:error, changeset} = LineItem.create(%{line_item_params(product) | order_id: -1})
+    # @tag stock_item_count: 1
+    # test "fails without an existing order or variant", %{stock_items: [si]} do
+    #   product = si.product
+    #   assert {:error, changeset} = LineItem.create(%{line_item_params(product) | order_id: -1})
 
-      assert %{order: ["does not exist"]} == errors_on(changeset)
+    #   assert %{order: ["does not exist"]} == errors_on(changeset)
 
-      assert {:error, changeset} = LineItem.create(line_item_params(product))
-      assert %{order_id: ["can't be blank"]} == errors_on(changeset)
+    #   assert {:error, changeset} = LineItem.create(line_item_params(product))
+    #   assert %{order_id: ["can't be blank"]} == errors_on(changeset)
 
-      order = insert(:order)
+    #   order = insert(:order)
 
-      assert {:error, changeset} =
-               LineItem.create(%{line_item_params(product) | product_id: nil, order_id: order.id})
+    #   assert {:error, changeset} =
+    #            LineItem.create(%{line_item_params(product) | product_id: nil, order_id: order.id})
 
-      assert %{product_id: ["can't be blank"]} == errors_on(changeset)
-    end
+    #   assert %{product_id: ["can't be blank"]} == errors_on(changeset)
+    # end
 
-    test "for an empty order" do
-      stock_item = insert(:stock_item)
-      variant = stock_item.product
-      order = insert(:order, line_items: [])
+    # test "for an empty order" do
+    #   stock_item = insert(:stock_item)
+    #   variant = stock_item.product
+    #   order = insert(:order, line_items: [])
 
-      assert {:ok, lineitem} = LineItem.create(%{line_item_params(variant) | order_id: order.id})
-    end
+    #   assert {:ok, lineitem} = LineItem.create(%{line_item_params(variant) | order_id: order.id})
+    # end
 
     @tag variant_count: 1
-    test "fails if stock insufficient", %{variants: [variant]} do
+    test "fails if stock insufficient and inventory tracking enabled", %{variants: [variant]} do
       order = insert(:order, line_items: [])
 
       assert {:error, changeset} =
@@ -96,42 +96,42 @@ defmodule Snitch.Data.Model.LineItemTest do
     end
   end
 
-  describe "update/1" do
-    setup :orders
+  # describe "update/1" do
+  #   setup :orders
 
-    test "with valid params", %{orders: [order]} do
-      stock_item = insert(:stock_item, count_on_hand: 5)
+  #   test "with valid params", %{orders: [order]} do
+  #     stock_item = insert(:stock_item, count_on_hand: 5)
 
-      product = stock_item.product
-      order = struct(order, line_items(%{order: order, variants: [product]}))
+  #     product = stock_item.product
+  #     order = struct(order, line_items(%{order: order, variants: [product]}))
 
-      [li] = order.line_items
+  #     [li] = order.line_items
 
-      params = %{quantity: li.quantity + 1}
+  #     params = %{quantity: li.quantity + 1}
 
-      assert {:ok, _} = LineItem.update(li, params)
-    end
-  end
+  #     assert {:ok, _} = LineItem.update(li, params)
+  #   end
+  # end
 
-  describe "delete/1 for order in `cart` state" do
-    setup :variants
-    setup :orders
+  # describe "delete/1 for order in `cart` state" do
+  #   setup :variants
+  #   setup :orders
 
-    @tag variant_count: 1
-    test "with valid params", %{variants: [v], orders: [order]} do
-      order = struct(order, line_items(%{order: order, variants: [v]}))
+  #   @tag variant_count: 1
+  #   test "with valid params", %{variants: [v], orders: [order]} do
+  #     order = struct(order, line_items(%{order: order, variants: [v]}))
 
-      [line_item] = order.line_items
+  #     [line_item] = order.line_items
 
-      {:ok, _} = LineItem.delete(line_item)
-      {:ok, order} = Order.get(order.id)
+  #     {:ok, _} = LineItem.delete(line_item)
+  #     {:ok, order} = Order.get(order.id)
 
-      assert [] =
-               order
-               |> Repo.preload(:line_items)
-               |> Map.fetch!(:line_items)
-    end
-  end
+  #     assert [] =
+  #              order
+  #              |> Repo.preload(:line_items)
+  #              |> Map.fetch!(:line_items)
+  #   end
+  # end
 
   defp good_line_items(context) do
     %{variants: vs} = context

--- a/apps/snitch_core/test/data/model/line_item_test.exs
+++ b/apps/snitch_core/test/data/model/line_item_test.exs
@@ -8,82 +8,82 @@ defmodule Snitch.Data.Model.LineItemTest do
   alias Snitch.Data.Model.{LineItem, Order}
   alias Snitch.Data.Model.GeneralConfiguration, as: GCModel
 
-  # describe "with valid params" do
-  #   setup :variants
-  #   setup :good_line_items
+  describe "with valid params" do
+    setup :variants
+    setup :good_line_items
 
-  #   test "update_unit_price/1", context do
-  #     %{line_items: line_items} = context
-  #     priced_items = LineItem.update_unit_price(line_items)
-  #     assert Enum.all?(priced_items, fn %{unit_price: price} -> not is_nil(price) end)
-  #   end
+    test "update_unit_price/1", context do
+      %{line_items: line_items} = context
+      priced_items = LineItem.update_unit_price(line_items)
+      assert Enum.all?(priced_items, fn %{unit_price: price} -> not is_nil(price) end)
+    end
 
-  #   test "compute_total/1", context do
-  #     %{line_items: line_items} = context
-  #     priced_items = LineItem.update_unit_price(line_items)
-  #     assert %Money{} = LineItem.compute_total(priced_items)
-  #   end
-  # end
+    test "compute_total/1", context do
+      %{line_items: line_items} = context
+      priced_items = LineItem.update_unit_price(line_items)
+      assert %Money{} = LineItem.compute_total(priced_items)
+    end
+  end
 
-  # describe "with invalid params" do
-  #   setup :variants
-  #   setup :bad_line_items
+  describe "with invalid params" do
+    setup :variants
+    setup :bad_line_items
 
-  #   test "update_unit_price/1", %{line_items: line_items} do
-  #     priced_items = LineItem.update_unit_price(line_items)
+    test "update_unit_price/1", %{line_items: line_items} do
+      priced_items = LineItem.update_unit_price(line_items)
 
-  #     assert [
-  #              %{quantity: 2, product_id: -1},
-  #              %{quantity: nil, unit_price: %Money{}, product_id: _},
-  #              %{quantity: 2, product_id: nil}
-  #            ] = priced_items
-  #   end
-  # end
+      assert [
+               %{quantity: 2, product_id: -1},
+               %{quantity: nil, unit_price: %Money{}, product_id: _},
+               %{quantity: 2, product_id: nil}
+             ] = priced_items
+    end
+  end
 
-  # describe "compute_total/1 with empty list" do
-  #   setup :verify_on_exit!
+  describe "compute_total/1 with empty list" do
+    setup :verify_on_exit!
 
-  #   test "when default currency is set in the store" do
-  #     config = insert(:general_config)
-  #     assert GCModel.fetch_currency() == config.currency
-  #     assert Money.zero(config.currency) == LineItem.compute_total([])
-  #   end
+    test "when default currency is set in the store" do
+      config = insert(:general_config)
+      assert GCModel.fetch_currency() == config.currency
+      assert Money.zero(config.currency) == LineItem.compute_total([])
+    end
 
-  #   test "when default currency is not set" do
-  #     assert GCModel.fetch_currency() == "USD"
-  #     assert Money.zero("USD") == LineItem.compute_total([])
-  #   end
-  # end
+    test "when default currency is not set" do
+      assert GCModel.fetch_currency() == "USD"
+      assert Money.zero("USD") == LineItem.compute_total([])
+    end
+  end
 
   describe "create/1" do
     setup :variants
     setup :stock_items_setup
 
-    # @tag stock_item_count: 1
-    # test "fails without an existing order or variant", %{stock_items: [si]} do
-    #   product = si.product
-    #   assert {:error, changeset} = LineItem.create(%{line_item_params(product) | order_id: -1})
+    @tag stock_item_count: 1
+    test "fails without an existing order or variant", %{stock_items: [si]} do
+      product = si.product
+      assert {:error, changeset} = LineItem.create(%{line_item_params(product) | order_id: -1})
 
-    #   assert %{order: ["does not exist"]} == errors_on(changeset)
+      assert %{order: ["does not exist"]} == errors_on(changeset)
 
-    #   assert {:error, changeset} = LineItem.create(line_item_params(product))
-    #   assert %{order_id: ["can't be blank"]} == errors_on(changeset)
+      assert {:error, changeset} = LineItem.create(line_item_params(product))
+      assert %{order_id: ["can't be blank"]} == errors_on(changeset)
 
-    #   order = insert(:order)
+      order = insert(:order)
 
-    #   assert {:error, changeset} =
-    #            LineItem.create(%{line_item_params(product) | product_id: nil, order_id: order.id})
+      assert {:error, changeset} =
+               LineItem.create(%{line_item_params(product) | product_id: nil, order_id: order.id})
 
-    #   assert %{product_id: ["can't be blank"]} == errors_on(changeset)
-    # end
+      assert %{product_id: ["can't be blank"]} == errors_on(changeset)
+    end
 
-    # test "for an empty order" do
-    #   stock_item = insert(:stock_item)
-    #   variant = stock_item.product
-    #   order = insert(:order, line_items: [])
+    test "for an empty order" do
+      stock_item = insert(:stock_item)
+      variant = stock_item.product
+      order = insert(:order, line_items: [])
 
-    #   assert {:ok, lineitem} = LineItem.create(%{line_item_params(variant) | order_id: order.id})
-    # end
+      assert {:ok, lineitem} = LineItem.create(%{line_item_params(variant) | order_id: order.id})
+    end
 
     @tag variant_count: 1
     test "fails if stock insufficient and inventory tracking enabled", %{variants: [variant]} do
@@ -96,42 +96,42 @@ defmodule Snitch.Data.Model.LineItemTest do
     end
   end
 
-  # describe "update/1" do
-  #   setup :orders
+  describe "update/1" do
+    setup :orders
 
-  #   test "with valid params", %{orders: [order]} do
-  #     stock_item = insert(:stock_item, count_on_hand: 5)
+    test "with valid params", %{orders: [order]} do
+      stock_item = insert(:stock_item, count_on_hand: 5)
 
-  #     product = stock_item.product
-  #     order = struct(order, line_items(%{order: order, variants: [product]}))
+      product = stock_item.product
+      order = struct(order, line_items(%{order: order, variants: [product]}))
 
-  #     [li] = order.line_items
+      [li] = order.line_items
 
-  #     params = %{quantity: li.quantity + 1}
+      params = %{quantity: li.quantity + 1}
 
-  #     assert {:ok, _} = LineItem.update(li, params)
-  #   end
-  # end
+      assert {:ok, _} = LineItem.update(li, params)
+    end
+  end
 
-  # describe "delete/1 for order in `cart` state" do
-  #   setup :variants
-  #   setup :orders
+  describe "delete/1 for order in `cart` state" do
+    setup :variants
+    setup :orders
 
-  #   @tag variant_count: 1
-  #   test "with valid params", %{variants: [v], orders: [order]} do
-  #     order = struct(order, line_items(%{order: order, variants: [v]}))
+    @tag variant_count: 1
+    test "with valid params", %{variants: [v], orders: [order]} do
+      order = struct(order, line_items(%{order: order, variants: [v]}))
 
-  #     [line_item] = order.line_items
+      [line_item] = order.line_items
 
-  #     {:ok, _} = LineItem.delete(line_item)
-  #     {:ok, order} = Order.get(order.id)
+      {:ok, _} = LineItem.delete(line_item)
+      {:ok, order} = Order.get(order.id)
 
-  #     assert [] =
-  #              order
-  #              |> Repo.preload(:line_items)
-  #              |> Map.fetch!(:line_items)
-  #   end
-  # end
+      assert [] =
+               order
+               |> Repo.preload(:line_items)
+               |> Map.fetch!(:line_items)
+    end
+  end
 
   defp good_line_items(context) do
     %{variants: vs} = context

--- a/apps/snitch_core/test/support/factory/product.ex
+++ b/apps/snitch_core/test/support/factory/product.ex
@@ -11,6 +11,7 @@ defmodule Snitch.Factory.Product do
           selling_price: Money.new("12.99", currency()),
           max_retail_price: Money.new("14.99", currency()),
           shipping_category: build(:shipping_category),
+          inventory_tracking: :product,
           state: :active
         }
       end


### PR DESCRIPTION
## Why?
To fix failure while adding line items to cart when inventory tracking is disabled.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->

## This change addresses the need by:
Checking whether the inventory tracking is enabled or diabled for a given product before it's presence in the stock.
<!--- List and detail all changes made in this PR. -->

[delivers #163724078](https://www.pivotaltracker.com/story/show/163724078)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

