### PR TITLE
Handle error on duplicating product name

### DIFF
--- a/apps/admin_app/lib/admin_app/product/search.ex
+++ b/apps/admin_app/lib/admin_app/product/search.ex
@@ -7,7 +7,7 @@ defmodule AdminApp.Product.SearchContext do
     Product
     |> where(
       [p],
-      (ilike(p.name, ^"%#{term}%") or ilike(p.sku, ^"%#{term}%")) and is_nil(p.deleted_at)
+      (ilike(p.name, ^"%#{term}%") or ilike(p.sku, ^"%#{term}%")) and p.deleted_at == ^0
     )
     |> preload([:images, :variants])
     |> Repo.all()

--- a/apps/snitch_core/lib/core/data/model/product.ex
+++ b/apps/snitch_core/lib/core/data/model/product.ex
@@ -112,7 +112,7 @@ defmodule Snitch.Data.Model.Product do
     |> join(:left, [p], v in Variation, v.child_product_id == p.id)
     |> where(
       [p, v],
-      p.state == "active" and is_nil(p.deleted_at) and p.id not in ^parent_product_ids
+      p.state == "active" and p.deleted_at == ^0 and p.id not in ^parent_product_ids
     )
   end
 

--- a/apps/snitch_core/lib/core/data/schema/product.ex
+++ b/apps/snitch_core/lib/core/data/schema/product.ex
@@ -26,6 +26,7 @@ defmodule Snitch.Data.Schema.Product do
   }
 
   alias Money.Ecto.Composite.Type, as: MoneyType
+  alias Snitch.Tools.EctoType.UnixTimestamp
 
   @type t :: %__MODULE__{}
 
@@ -33,7 +34,7 @@ defmodule Snitch.Data.Schema.Product do
     field(:name, :string, null: false, default: "")
     field(:description, :string)
     field(:available_on, :utc_datetime)
-    field(:deleted_at, :utc_datetime)
+    field(:deleted_at, UnixTimestamp, default: 0)
     field(:discontinue_on, :utc_datetime)
     field(:slug, :string)
 
@@ -198,6 +199,7 @@ defmodule Snitch.Data.Schema.Product do
     changeset
     |> validate_amount(:selling_price)
     |> NameSlug.maybe_generate_slug()
+    |> unique_constraint(:slug, name: :snitch_products_slug_deleted_at_index)
   end
 
   def product_by_category_query(taxon_id) do

--- a/apps/snitch_core/lib/core/data/schema/product.ex
+++ b/apps/snitch_core/lib/core/data/schema/product.ex
@@ -168,18 +168,17 @@ defmodule Snitch.Data.Schema.Product do
 
   def delete_changeset(product, _params \\ %{}) do
     product = Repo.preload(product, [:products])
+    current_time = DateTime.utc_now() |> DateTime.to_unix()
 
     variant_params =
       product.products
-      |> Enum.map(
-        &%{"state" => "deleted", "id" => &1.id, "deleted_at" => NaiveDateTime.utc_now()}
-      )
+      |> Enum.map(&%{"state" => "deleted", "id" => &1.id, "deleted_at" => current_time})
 
     params = %{
       "id" => product.id,
       "state" => "deleted",
       "products" => variant_params,
-      "deleted_at" => NaiveDateTime.utc_now()
+      "deleted_at" => current_time
     }
 
     product
@@ -214,8 +213,10 @@ defmodule Snitch.Data.Schema.Product do
   end
 
   def set_delete_fields(%Ecto.Query{} = product_query) do
+    current_time = DateTime.utc_now() |> DateTime.to_unix()
+
     from(p in product_query,
-      update: [set: [state: "deleted", deleted_at: ^NaiveDateTime.utc_now(), taxon_id: nil]]
+      update: [set: [state: "deleted", deleted_at: ^current_time, taxon_id: nil]]
     )
   end
 

--- a/apps/snitch_core/lib/core/data/schema/product.ex
+++ b/apps/snitch_core/lib/core/data/schema/product.ex
@@ -199,7 +199,10 @@ defmodule Snitch.Data.Schema.Product do
     changeset
     |> validate_amount(:selling_price)
     |> NameSlug.maybe_generate_slug()
-    |> unique_constraint(:slug, name: :snitch_products_slug_deleted_at_index)
+    |> unique_constraint(:name,
+      name: :snitch_products_slug_deleted_at_index,
+      message: "unique name for products"
+    )
   end
 
   def product_by_category_query(taxon_id) do

--- a/apps/snitch_core/lib/core/tools/elasticsearch/product/store.ex
+++ b/apps/snitch_core/lib/core/tools/elasticsearch/product/store.ex
@@ -76,7 +76,7 @@ defmodule Snitch.Tools.ElasticSearch.Product.Store do
     end
   end
 
-  defp update_sellable_product_to_es(%{state: :active, deleted_at: nil} = product, :create),
+  defp update_sellable_product_to_es(%{state: :active, deleted_at: 0} = product, :create),
     do:
       Elasticsearch.put_document!(
         EC,

--- a/apps/snitch_core/priv/repo/migrations/20190219100843_alter_products_table.exs
+++ b/apps/snitch_core/priv/repo/migrations/20190219100843_alter_products_table.exs
@@ -1,0 +1,8 @@
+defmodule Snitch.Repo.Migrations.AlterProductsTable do
+  use Ecto.Migration
+
+  def change do
+     drop unique_index("snitch_products", [:slug])
+     create unique_index("snitch_products", [:slug, :deleted_at])
+  end
+end

--- a/apps/snitch_core/test/data/model/product_test.exs
+++ b/apps/snitch_core/test/data/model/product_test.exs
@@ -200,6 +200,7 @@ defmodule Snitch.Data.Model.ProductTest do
       product = insert(:product, attrs)
       variant = product.products |> List.first()
       variation = insert(:variation, %{parent_product: product, child_product: variant})
+
       sellable_products = Product.sellable_products_query() |> Repo.all() |> Enum.map(& &1.id)
       assert Enum.member?(sellable_products, variant.id) == true
       refute Enum.member?(sellable_products, product.id)

--- a/apps/snitch_core/test/data/schema/product_test.exs
+++ b/apps/snitch_core/test/data/schema/product_test.exs
@@ -47,7 +47,7 @@ defmodule Snitch.Data.Schema.ProductTest do
     {:ok, _} = Repo.insert(changeset)
     cs = Product.create_changeset(%Product{}, params)
     {:error, changeset} = Repo.insert(cs)
-    assert %{slug: ["has already been taken"]} == errors_on(changeset)
+    assert %{name: ["unique name for products"]} == errors_on(changeset)
   end
 
   test "test invalid data for create_changeset/2" do

--- a/apps/snitch_core/test/data/schema/product_test.exs
+++ b/apps/snitch_core/test/data/schema/product_test.exs
@@ -28,6 +28,28 @@ defmodule Snitch.Data.Schema.ProductTest do
     assert {:ok, _product} = Repo.insert(changeset)
   end
 
+  test "create_changeset/2 fails for duplicate slug" do
+    taxon = insert(:taxon)
+    shipping_category = insert(:shipping_category)
+    tax_class = insert(:tax_class)
+
+    params = %{
+      name: "HTC Desire 620",
+      description: "HTC desire 620",
+      selling_price: Money.new("12.99", currency()),
+      max_retail_price: Money.new("14.99", currency()),
+      taxon_id: taxon.id,
+      shipping_category_id: shipping_category.id,
+      tax_class_id: tax_class.id
+    }
+
+    changeset = Product.create_changeset(%Product{}, params)
+    {:ok, _} = Repo.insert(changeset)
+    cs = Product.create_changeset(%Product{}, params)
+    {:error, changeset} = Repo.insert(cs)
+    assert %{slug: ["has already been taken"]} == errors_on(changeset)
+  end
+
   test "test invalid data for create_changeset/2" do
     params = %{
       description: "HTC desire 620"


### PR DESCRIPTION
## Why?
 Same product name was being entered for two different products.
 At DB level unique constraint is not for the name but, it is for the slug. This uniqueness constraint should be applicable for the products which are not deleted in the system, hence, uniqueness is now  checked on a combination on slug name and deleted_at product field. 

## This change addresses the need by:
 Created a unique_index on combination of `slug` and `deleted_at` in migrations.
 Added unique_constraint on slug and deleted_at in product.ex (schema)

[delivers #164069814]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

