### PR TITLE
Promotion re-evaluation for line_item CRUD

### DIFF
--- a/apps/snitch_api/lib/snitch_api_web/controllers/line_item_controller.ex
+++ b/apps/snitch_api/lib/snitch_api_web/controllers/line_item_controller.ex
@@ -3,9 +3,8 @@ defmodule SnitchApiWeb.LineItemController do
 
   alias Snitch.Data.Model.LineItem, as: LineItemModel
   alias Snitch.Data.Model.Order, as: OrderModel
-  alias Snitch.Data.Schema.{LineItem, Variant, Product}
+  alias Snitch.Data.Schema.{LineItem, Product}
   alias Snitch.Core.Tools.MultiTenancy.Repo
-  import Ecto.Query
   alias SnitchApi.Order, as: OrderContext
 
   plug(SnitchApiWeb.Plug.DataToAttributes)
@@ -35,7 +34,7 @@ defmodule SnitchApiWeb.LineItemController do
 
   def guest_line_item(conn, %{"order_id" => order_id} = params) do
     with {:ok, line_item} <- add_line_item(params) do
-      order = OrderContext.load_order(line_item.order_id)
+      order = OrderContext.load_order(order_id)
 
       conn
       |> put_status(200)

--- a/apps/snitch_core/lib/core/data/model/line_item.ex
+++ b/apps/snitch_core/lib/core/data/model/line_item.ex
@@ -6,7 +6,7 @@ defmodule Snitch.Data.Model.LineItem do
 
   import Ecto.Changeset, only: [change: 1]
 
-  alias Snitch.Data.Model.{Variant, Product}
+  alias Snitch.Data.Model.Product
   alias Snitch.Data.Schema.LineItem
   alias Snitch.Domain.Order
   alias Snitch.Tools.Money, as: MoneyTools

--- a/apps/snitch_core/lib/core/data/model/order.ex
+++ b/apps/snitch_core/lib/core/data/model/order.ex
@@ -9,6 +9,8 @@ defmodule Snitch.Data.Model.Order do
   alias Snitch.Data.Model.LineItem, as: LineItemModel
 
   @order_states ["confirmed", "complete"]
+  @non_complete_order_states ~w(cart address delivery payment)a
+
   @doc """
   Creates an order with supplied `params` and `line_items`.
 
@@ -44,17 +46,16 @@ defmodule Snitch.Data.Model.Order do
   @doc """
   Returns an `order` struct for the supplied `user_id`.
 
-  An existing `order` associated with the user is present in either `cart` or
-  `address` state is returned if found. If no order is present for the user
-  in `cart` or `address` state a new order is created returned.
+  An existing `order` associated with the user present in "#{inspect(@non_complete_order_states)}"
+  state is returned if found. If no order is present for the user
+  in these states, a new order is created and returned.
   """
   @spec user_order(non_neg_integer) :: Order.t()
   def user_order(user_id) do
     query =
       from(
         order in Order,
-        where:
-          order.user_id == ^user_id and order.state in ["cart", "address", "delivery", "payment"]
+        where: order.user_id == ^user_id and order.state in ^@non_complete_order_states
       )
 
     query

--- a/apps/snitch_core/lib/core/data/model/promotion/order_eligibility.ex
+++ b/apps/snitch_core/lib/core/data/model/promotion/order_eligibility.ex
@@ -6,7 +6,7 @@ defmodule Snitch.Data.Model.Promotion.OrderEligibility do
   use Snitch.Data.Model
   alias Snitch.Data.Model.PromotionAdjustment
 
-  @valid_order_states ~w(delivery address)a
+  @valid_order_states ~w(delivery address cart)a
   @success_message "promotion applicable"
   @error_message "coupon not applicable"
   @coupon_applied "coupon already applied"

--- a/apps/snitch_core/lib/core/data/model/promotion/promotion.ex
+++ b/apps/snitch_core/lib/core/data/model/promotion/promotion.ex
@@ -194,9 +194,9 @@ defmodule Snitch.Data.Model.Promotion do
     end
   end
 
-  def update_usage_count(promotion) do
+  def update_usage_count(promotion, count) do
     current_usage_count = promotion.current_usage_count
-    params = %{current_usage_count: current_usage_count + 1}
+    params = %{current_usage_count: current_usage_count + count}
 
     QH.update(Promotion, params, promotion, Repo)
   end
@@ -216,6 +216,7 @@ defmodule Snitch.Data.Model.Promotion do
   defp process_adjustments(order, promotion) do
     case PromotionAdjustment.process_adjustments(order, promotion) do
       {:ok, _data} ->
+        update_usage_count(promotion, 1)
         {:ok, @messages.coupon_applied}
 
       {:error, _message} = error ->

--- a/apps/snitch_core/lib/core/domain/promotion/cart.ex
+++ b/apps/snitch_core/lib/core/domain/promotion/cart.ex
@@ -1,0 +1,149 @@
+defmodule Snitch.Domain.Promotion.CartHelper do
+  @moduledoc """
+  Module exposes functions to handle promotion related checks on
+  an order.
+
+  If an order has any promotion associated with it then, on addition, updation
+  or removal of lineitem it may become eligible or ineligible for the promotion.
+  """
+
+  import Ecto.Query
+  alias Ecto.Multi
+  alias Snitch.Core.Tools.MultiTenancy.Repo
+  alias Snitch.Data.Schema.{Adjustment, Promotion, PromotionAdjustment}
+  alias Snitch.Data.Model.Promotion.Eligibility
+  alias Snitch.Data.Model.Promotion, as: PromotionModel
+  alias Snitch.Data.Model.PromotionAdjustment, as: PromoAdjModel
+  alias Snitch.Data.Model.Promotion.OrderEligibility
+
+  @success_message "coupon applied"
+  @failure_message "promotion not applicable"
+
+  @doc """
+  Revaluates the promotion for order for which the line_item was
+  touched(created, updated or removed).
+
+  Finds out the `promotion` for which the `order` has active promotios.
+
+  > Active promotions for an order is found out by checking if `eligible` promotion related
+  > adjustments are present for the order.
+  > See Snitch.Data.Model.PromotionAdjustment
+  """
+  @spec evaluate_promotion(Order.t()) :: {:ok, map} | {:error, String.t()}
+  def evaluate_promotion(order) do
+    case get_promotion(order) do
+      nil ->
+        {:error, "no promotion applied to order"}
+
+      promotion ->
+        process_adjustments(order, promotion)
+    end
+  end
+
+  # Handles adjustments for the promotion returned for the order. If the order
+  # becomes ineligible for the promotion then removes all the records for the order
+  # and the promotion. In case order is still eligible for promotion new adjustments
+  # as line item has modified the order and promotion actions will act differently
+  # on the modified order. The older adjustments existing for the order are removed.
+  defp process_adjustments(order, promotion) do
+    with {:ok, _message} <- eligibility_checks(order, promotion) do
+      if PromotionModel.activate?(order, promotion) do
+        activate_recent_adjustments(order, promotion)
+      end
+    else
+      {:error, _message} ->
+        remove_adjustments(order, promotion)
+    end
+  end
+
+  defp remove_adjustments(order, promotion) do
+    Multi.new()
+    |> Multi.delete_all(
+      :remove_adjustments_for_promotion,
+      from(
+        adj in Adjustment,
+        join: p_adj in PromotionAdjustment,
+        on: p_adj.adjustment_id == adj.id,
+        where: p_adj.order_id == ^order.id and p_adj.promotion_id == ^promotion.id
+      )
+    )
+    |> Multi.run(:update_promotion_count, fn _ ->
+      PromotionModel.update_usage_count(promotion, -1)
+    end)
+    |> persist()
+  end
+
+  defp activate_recent_adjustments(order, promotion) do
+    adjustments = PromoAdjModel.order_adjustments_for_promotion(order, promotion)
+
+    old_adjustment_ids =
+      Enum.flat_map(adjustments, fn adj ->
+        if adj.eligible == true, do: [adj.id], else: []
+      end)
+
+    new_adjustment_ids =
+      Enum.flat_map(adjustments, fn adj ->
+        if adj.eligible == false, do: [adj.id], else: []
+      end)
+
+    Multi.new()
+    |> Multi.delete_all(
+      :remove_old_adjustments,
+      from(adj in Adjustment, where: adj.id in ^old_adjustment_ids)
+    )
+    |> Multi.update_all(
+      :mark_new_adjustment_as_eligible,
+      from(adj in Adjustment, where: adj.id in ^new_adjustment_ids),
+      set: [eligible: true]
+    )
+    |> persist()
+  end
+
+  defp get_promotion(order) do
+    case get_active_promotion_id(order) do
+      nil ->
+        nil
+
+      id ->
+        Repo.get(Promotion, id)
+    end
+  end
+
+  defp get_active_promotion_id(order) do
+    query =
+      from(adj in Adjustment,
+        join: p_adj in PromotionAdjustment,
+        on: adj.id == p_adj.adjustment_id,
+        where: p_adj.order_id == ^order.id and adj.eligible == true,
+        limit: 1,
+        select: p_adj.promotion_id
+      )
+
+    Repo.one(query)
+  end
+
+  # Run the accumulated multi struct
+  defp persist(multi) do
+    case Repo.transaction(multi) do
+      {:ok, data} ->
+        {:ok, data}
+
+      {:error, _, data, _} ->
+        {:error, data}
+    end
+  end
+
+  defp eligibility_checks(order, promotion) do
+    with true <- Eligibility.promotion_level_check(promotion),
+         {true, _message} <- OrderEligibility.order_promotionable(order),
+         {true, _message} <- OrderEligibility.rules_check(order, promotion) do
+      {:ok, @success_message}
+    else
+      {false, message} ->
+        {:error, message}
+
+      false ->
+        {:error, @failure_message}
+    end
+  end
+end

--- a/apps/snitch_core/priv/repo/migrations/20190218071130_alter_promo_adjustments_cascade_delete.exs
+++ b/apps/snitch_core/priv/repo/migrations/20190218071130_alter_promo_adjustments_cascade_delete.exs
@@ -1,0 +1,10 @@
+defmodule Snitch.Repo.Migrations.AlterPromoAdjustmentsCascadeDelete do
+  use Ecto.Migration
+
+  def change do
+    execute "ALTER TABLE snitch_promotion_adjustments DROP CONSTRAINT snitch_promotion_adjustments_adjustment_id_fkey"
+    alter table("snitch_promotion_adjustments") do
+      modify(:adjustment_id, references("snitch_adjustments", on_delete: :delete_all))
+    end
+  end
+end

--- a/apps/snitch_core/test/data/model/adjustment/promotion_adjustment_test.exs
+++ b/apps/snitch_core/test/data/model/adjustment/promotion_adjustment_test.exs
@@ -4,7 +4,7 @@ defmodule Snitch.Data.Model.PromotionAdjustmentTest do
   use ExUnit.Case
   use Snitch.DataCase
   import Snitch.Factory
-  alias Snitch.Data.Model.{Promotion, PromotionAdjustment}
+  alias Snitch.Data.Model.{Promotion, PromotionAdjustment, Adjustment}
 
   describe "promotion adjustment queries" do
     setup do
@@ -46,8 +46,9 @@ defmodule Snitch.Data.Model.PromotionAdjustmentTest do
     test "order_adjustments_for_promotion/2", context do
       %{order: order, promotion1: promotion1, promotion2: promotion2} = context
 
-      # since promotion is applied twice there should be 8 adjustments
+      # since two promotions are applied twice there should be 8 adjustments
       # promotion1 -> 1 order + 3 lineitems = 4
+      # promotion2 -> 1 order + 3 lineitems = 4
       Promotion.activate?(order, promotion1)
       Promotion.activate?(order, promotion2)
 
@@ -71,8 +72,6 @@ defmodule Snitch.Data.Model.PromotionAdjustmentTest do
       adjustments = PromotionAdjustment.order_adjustments_for_promotion(order, promotion1)
       data = PromotionAdjustment.eligible_order_adjustments(order)
       assert data == []
-
-      current_adj_ids = Enum.map(adjustments, fn adjustment -> adjustment.id end)
 
       # activate adjustments for promotion1
       {:ok, _data} = PromotionAdjustment.process_adjustments(order, promotion1)

--- a/apps/snitch_core/test/data/model/order_test.exs
+++ b/apps/snitch_core/test/data/model/order_test.exs
@@ -130,7 +130,7 @@ defmodule Snitch.Data.Model.OrderTest do
   end
 
   describe "order" do
-    test "count by state", %{order_params: params, variants: vs} do
+    test "count by state", %{order_params: params} do
       {:ok, order} = Order.create(params)
       Order.partial_update(order, %{state: :confirmed})
 
@@ -148,7 +148,7 @@ defmodule Snitch.Data.Model.OrderTest do
       assert order_state_count.state == :confirmed
     end
 
-    test "count by date", %{order_params: params, variants: vs} do
+    test "count by date", %{order_params: params} do
       {:ok, order} = Order.create(params)
 
       next_date =
@@ -162,6 +162,24 @@ defmodule Snitch.Data.Model.OrderTest do
         Order.get_order_count_by_date(order.inserted_at, next_date) |> List.first()
 
       assert order_date_count.count == 1
+    end
+  end
+
+  describe "user_order/1" do
+    test "returns same order if, it's in non complete state" do
+      user = insert(:user)
+      order = insert(:order, user: user, state: :cart)
+
+      assert {:ok, user_order} = Order.user_order(user.id)
+      assert user_order.id == order.id
+    end
+
+    test "returns new order if, order in any completed state" do
+      user = insert(:user)
+      order = insert(:order, user: user, state: :confirmed)
+
+      assert {:ok, user_order} = Order.user_order(user.id)
+      assert user_order.id != order.id
     end
   end
 

--- a/apps/snitch_core/test/data/model/promotion/eligibility_test.exs
+++ b/apps/snitch_core/test/data/model/promotion/eligibility_test.exs
@@ -42,7 +42,7 @@ defmodule Snitch.Data.Model.Promotion.EligibilityTest do
 
   describe "order_level_check/2" do
     test "fails as order not in valid state" do
-      order = insert(:order, state: :cart)
+      order = insert(:order, state: :confirmed)
       promotion = insert(:promotion, match_policy: "all")
 
       assert {false, message} = Eligibility.order_level_check(order, promotion)

--- a/apps/snitch_core/test/data/model/promotion/order_eligibility_test.exs
+++ b/apps/snitch_core/test/data/model/promotion/order_eligibility_test.exs
@@ -21,7 +21,7 @@ defmodule Snitch.Data.Model.Promotion.OrderEligibilityTest do
     end
 
     test "fails if order state not valid for promotion" do
-      order = insert(:order, state: :cart)
+      order = insert(:order, state: :confirmed)
 
       assert {false, message} = OrderEligibility.valid_order_state(order)
       assert message == "promotion not applicable to order"

--- a/apps/snitch_core/test/data/model/promotion/promotion_test.exs
+++ b/apps/snitch_core/test/data/model/promotion/promotion_test.exs
@@ -337,13 +337,10 @@ defmodule Snitch.Data.Model.PromotionTest do
       assert message == @messages.coupon_applied
 
       old_adjustments = PromotionAdjustment.order_adjustments_for_promotion(order, promotion)
+      assert old_adjustments == []
 
       new_adjustments =
         PromotionAdjustment.order_adjustments_for_promotion(order, promotion_other)
-
-      Enum.each(old_adjustments, fn adjustment ->
-        assert adjustment.eligible == false
-      end)
 
       Enum.each(new_adjustments, fn adjustment ->
         assert adjustment.eligible == true

--- a/apps/snitch_core/test/domain/promotion/cart_test.exs
+++ b/apps/snitch_core/test/domain/promotion/cart_test.exs
@@ -1,0 +1,151 @@
+defmodule Snitch.Domain.Promotion.CartHelperTest do
+  use ExUnit.Case
+  use Snitch.DataCase
+  import Snitch.Factory
+  alias Snitch.Domain.Promotion.CartHelper
+  alias Snitch.Data.Model.{Promotion, PromotionAdjustment, LineItem}
+
+  describe "evaluate_promotion/1" do
+    test "all adjustments are removed if promotion becomes ineligible" do
+      item_info = %{quantity: 2, price: Money.new!(currency(), 10)}
+
+      %{order: order, line_items: line_items, order_total: order_total, product_ids: product_ids} =
+        setup_order(item_info)
+
+      [line_item_1, _, _] = line_items
+
+      order_params = %{order: order, order_total: order_total, product_ids: product_ids}
+      apply_promotion(order_params)
+
+      adjustments = PromotionAdjustment.order_adjustments(order)
+
+      assert adjustments != []
+
+      Enum.each(adjustments, fn adj ->
+        assert adj.eligible == true
+      end)
+
+      # Remove a line item such that order becomes ineligible for promotion.
+      LineItem.delete(line_item_1)
+
+      assert {:ok, _data} = CartHelper.evaluate_promotion(order)
+      adjustments = PromotionAdjustment.order_adjustments(order)
+      assert adjustments == []
+    end
+
+    test "returns 'no promotion found' if promotion not applied on order" do
+      item_info = %{quantity: 2, price: Money.new!(currency(), 10)}
+      %{order: order} = setup_order(item_info)
+
+      assert {:error, message} = CartHelper.evaluate_promotion(order)
+      assert message == "no promotion applied to order"
+    end
+
+    test "new adjustments created for order as line items touched" do
+      item_info = %{quantity: 2, price: Money.new!(currency(), 10)}
+
+      %{order: order, line_items: line_items, order_total: order_total, product_ids: product_ids} =
+        setup_order(item_info)
+
+      [line_item_1, _, _] = line_items
+
+      order_params = %{order: order, order_total: order_total, product_ids: product_ids}
+      apply_promotion(order_params)
+
+      adjustments = PromotionAdjustment.order_adjustments(order)
+
+      assert adjustments != []
+
+      Enum.each(adjustments, fn adj ->
+        assert adj.eligible == true
+      end)
+
+      LineItem.update(line_item_1, %{quantity: 3})
+      assert {:ok, _data} = CartHelper.evaluate_promotion(order)
+
+      new_adjustments = PromotionAdjustment.order_adjustments(order)
+      assert MapSet.disjoint?(MapSet.new(adjustments), MapSet.new(new_adjustments))
+    end
+  end
+
+  defp apply_promotion(order_params) do
+    action_manifest = %{order_action: Decimal.new(10), line_item_action: Decimal.new(10)}
+    %{order: order, order_total: order_total, product_ids: product_ids} = order_params
+
+    item_total_cost = Decimal.sub(order_total.amount, 1)
+
+    rule_manifest = %{item_total_cost: item_total_cost, product_ids: product_ids}
+
+    promotion = insert(:promotion)
+    set_rules_and_actions(promotion, rule_manifest, action_manifest)
+
+    {:ok, _message} = Promotion.apply(order, promotion.code)
+
+    %{promotion: promotion}
+  end
+
+  defp set_rules_and_actions(promotion, rule_manifest, action_manifest) do
+    %{item_total_cost: cost, product_ids: product_ids} = rule_manifest
+    %{order_action: order_action_data, line_item_action: line_item_action_data} = action_manifest
+
+    insert(:order_total_rule,
+      promotion: promotion,
+      preferences: %{lower_range: cost, upper_range: Decimal.new(0)}
+    )
+
+    insert(:product_rule,
+      promotion: promotion,
+      preferences: %{match_policy: "all", product_list: product_ids}
+    )
+
+    insert(:promotion_order_action,
+      preferences: %{
+        calculator_module: "Elixir.Snitch.Domain.Calculator.FlatRate",
+        calculator_preferences: %{amount: order_action_data}
+      },
+      promotion: promotion
+    )
+
+    insert(:promotion_line_item_action,
+      preferences: %{
+        calculator_module: "Elixir.Snitch.Domain.Calculator.FlatRate",
+        calculator_preferences: %{amount: line_item_action_data}
+      },
+      promotion: promotion
+    )
+  end
+
+  defp setup_order(item_info) do
+    %{quantity: quantity, price: price} = item_info
+
+    products = insert_list(3, :product, promotionable: true, selling_price: price)
+
+    order = insert(:order, state: "delivery")
+
+    line_items =
+      Enum.map(products, fn product ->
+        insert(:line_item,
+          order: order,
+          product: product,
+          quantity: quantity,
+          unit_price: product.selling_price
+        )
+      end)
+
+    cost =
+      Enum.reduce(line_items, Money.new!(currency(), 0), fn item, acc ->
+        sum = Money.mult!(item.unit_price, item.quantity)
+        Money.add!(acc, sum)
+      end)
+
+    product_ids = Enum.map(products, fn product -> product.id end)
+
+    %{
+      order: order,
+      line_items: line_items,
+      products: products,
+      product_ids: product_ids,
+      order_total: cost
+    }
+  end
+end


### PR DESCRIPTION



## Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->
If an order has promotion applied to it, then if any of the line items
are touched(updated, removed) or a new line item is added, promotion
associated with it needs to be re-evaluated so that right adjustments
are present for the order.
## This change addresses the need by:
<!--- List and detail all changes made in this PR. -->
This change
- Adds a module to handle promotion re-evaluation whenever line items
  of an order are added, removed or updated.
- The ineligible adjustments for an order are now removed so that
  only eligible adjustments are present.
[delivers #163001984]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

