### PR TITLE
add missing description field in promotion create

### DIFF
--- a/apps/admin_app/lib/admin_app_web/views/promotion_view.ex
+++ b/apps/admin_app/lib/admin_app_web/views/promotion_view.ex
@@ -43,6 +43,7 @@ defmodule AdminAppWeb.PromotionView do
         code: promotion.code,
         starts_at: promotion.starts_at,
         expires_at: promotion.expires_at,
+        description: promotion.description,
         usage_count: promotion.current_usage_count,
         usage_limit: promotion.usage_limit,
         match_policy: promotion.match_policy,

--- a/apps/admin_app/test/admin_app_web/controllers/promotion_controller_test.exs
+++ b/apps/admin_app/test/admin_app_web/controllers/promotion_controller_test.exs
@@ -72,7 +72,8 @@ defmodule AdminAppWeb.PromotionControllerTest do
         starts_at: Timex.shift(DateTime.utc_now(), hours: 2),
         expires_at: Timex.shift(DateTime.utc_now(), hours: 8),
         rules: @rule_params,
-        actions: @action_params
+        actions: @action_params,
+        description: "5% off on goods."
       }
 
       params = %{"data" => params}


### PR DESCRIPTION
## Why?
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- If it delivers a story on the Pivotal tracker, please link to it here. -->
The description was not being returned after promotion creation.

## This change addresses the need by:
<!--- List and detail all changes made in this PR. -->
- Adds `description` field to list of fields being returned.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

