### PR TITLE
API accessible from docker container

### DIFF
--- a/config/docker/dev/Dockerfile-dev
+++ b/config/docker/dev/Dockerfile-dev
@@ -5,6 +5,7 @@ FROM elixir:1.7.3-slim as builder
 # 2. `/apps/snitch_core/config/dev.exs' file
 
 EXPOSE 4000
+EXPOSE 3000
 
 ENV APP_HOME /avia-backend
 ENV AWS_ACCESS_KEY_ID dasdas

--- a/config/docker/dev/docker-compose-dev.yml
+++ b/config/docker/dev/docker-compose-dev.yml
@@ -7,6 +7,7 @@ services:
     container_name: aviacommerce-dev
     ports:
       - "4000:4000"
+      - "3000:3000"
     depends_on:
       - db
       - elasticsearch

--- a/config/docker/dev/docker-dev-provision.sh
+++ b/config/docker/dev/docker-dev-provision.sh
@@ -3,5 +3,4 @@ mix ecto.create
 mix ecto.migrate
 mix run apps/snitch_core/priv/repo/seed/seeds.exs
 mix cmd --app snitch_core mix elasticsearch.build products --cluster Snitch.Tools.ElasticsearchCluster
-mix phx.server
-
+iex -S mix phx.server


### PR DESCRIPTION
## Why?
APIs were not accessible from docker containers for development environment

## This change addresses the need by:
Exposed 3000 port of docker container and mapped it with 3000 port of host system.

[delivers #164328202]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

