### PR TITLE
Tests for order model and schema

### DIFF
--- a/apps/snitch_core/test/data/schema/order_test.exs
+++ b/apps/snitch_core/test/data/schema/order_test.exs
@@ -73,6 +73,18 @@ defmodule Snitch.Data.Schema.OrderTest do
       cs = Order.create_changeset(build(:order), params)
       assert cs.valid?
     end
+
+    test "fails for non-existent user_id", %{user: user} do
+      params = %{
+        @order_params
+        | user_id: -1,
+          line_items: []
+      }
+
+      cs = Order.create_changeset(%Order{}, params)
+      {:error, changeset} = Repo.insert(cs)
+      assert %{user_id: ["does not exist"]} == errors_on(changeset)
+    end
   end
 
   describe "create_for_guest_changeset/2" do

--- a/apps/snitch_core/test/support/factory/rating.ex
+++ b/apps/snitch_core/test/support/factory/rating.ex
@@ -46,7 +46,7 @@ defmodule Snitch.Factory.Rating do
         count = Map.get(context, :rating_option_count, 2)
         [rating_options: insert_list(count, :rating_option, rating: rating)]
       end
-      
+
       def reviews(context) do
         rating_option = insert(:rating_option)
         count = Map.get(context, :review_count, 1)


### PR DESCRIPTION
## Why?
Coverage was less for order's model as well as for its schema.

## This change addresses the need by:
Added test cases to increase the coverage.
  In order_test.exs(model)
  - Test cases added for delete/1, get/1, get_all/0 , user_order/1 and get_all_with_preloads/1
  Added a test case for checking uniqueness of user_id in order_test.exs(schema)

[delivers #164457764]

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read [CONTRIBUTING.md][contributing].
- [ ] My code follows the [style guidelines][contributing] of this project.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] My code does not generate any (new) [`credo`][credo] and compile-time warnings.
- [ ] I have updated the documentation wherever necessary.
- [ ] I have added tests to cover my changes.

[contributing]: https://github.com/aviabird/snitch/CONTRIBUTING.md
[credo]: https://github.com/rrrene/credo

